### PR TITLE
Address minor issues surfaced via testing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ workflows:
       - py27:
           requires:
             - lint
+      - py35:
+          requires:
+            - lint
       - py36:
           requires:
             - lint
@@ -70,5 +73,6 @@ workflows:
       - functional:
           requires:
             - py27
+            - py35
             - py36
             - py37

--- a/tokendito/__main__.py
+++ b/tokendito/__main__.py
@@ -15,19 +15,19 @@ from future import standard_library
 standard_library.install_aliases()
 
 
-def main():  # needed for console script
+def main(args=None):  # needed for console script
     """Packge entry point."""
     if __package__ is None:
         import os.path
         path = os.path.dirname(os.path.dirname(__file__))
         sys.path[0:0] = [path]
     from tokendito.tool import cli
-    return cli()
-
-
-if __name__ == '__main__':
     try:
-        sys.exit(main())
+        return cli(args)
     except KeyboardInterrupt:
         print('\nInterrupted')
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/tokendito/tokendito.py
+++ b/tokendito/tokendito.py
@@ -14,19 +14,19 @@ from future import standard_library
 standard_library.install_aliases()
 
 
-def main():  # needed for console script
+def main(args=None):  # needed for console script
     """Packge entry point."""
     if __package__ is None:
         import os.path
         path = os.path.dirname(os.path.dirname(__file__))
         sys.path[0:0] = [path]
     from tokendito.tool import cli
-    return cli()
+    return cli(args)
 
 
 if __name__ == '__main__':
     try:
-        sys.exit(main())
+        sys.exit(main(sys.argv[1:]))
     except KeyboardInterrupt:
         print('\nInterrupted')
         sys.exit(1)

--- a/tokendito/tool.py
+++ b/tokendito/tool.py
@@ -18,10 +18,10 @@ from tokendito import settings
 standard_library.install_aliases()
 
 
-def cli():
+def cli(args):
     """Tokendito retrieves AWS credentials after authenticating with Okta."""
     # Set some required initial values
-    args = helpers.setup()
+    args = helpers.setup(args)
 
     logging.debug(
         "tokendito retrieves AWS credentials after authenticating with Okta."


### PR DESCRIPTION
     These fixes introduce no new functionality, or change tool
     functionality.

     * Move KeyboardInterrupt handling to a better place. The script as
       installed by pip bypassed the handler.
     * Separate display_function to display to stdout. This is required to
       work around https://bugs.python.org/issue18920
     * `main()` now takes arguments, so that `setup()` can be parametrized
       in turn.
     * Added py35 testing to CircleCI, as we missed it last time around.
     * Added evaluation for `args.config_file` as it was missing.
     * Added handling of byte literals to `to_unicode()` as it was missing
     * Some functions changed names for consistency.
     * `process_environment()`, `process_ini_file()`, and `process_arguments()`
        were refactored as they derived more values from the environment than
        what the application needs.
     * `mfa_response`, `mfa_method`, and `role_arn` can now be passed in via
       the matching environment variables `MFA_RESPONSE`, `MFA_METOHOD`,
       `ROLE_ARN`.
     * processing of the okta App URL was moved to its own function for
       clarity.

     N.B.: `mfa_mehod`, `mfa_response`, and `role_arn` should probably be
     deprecated in favor of `okfa_mfa_method`, `okta_mfa_response`, and
     `aws_role_arn` (or a separate namespace altogether). Doing this would
     have implications in how configuration files are set up.

