### PR TITLE
Change CircleCI for Github Actions (1 of 2)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,105 @@
+name: Test, Build, and Publish
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '[0-9].[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize, reopened]
+
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Run Tox lint
+        run: |
+          tox -e lint
+  test:
+    name: Tox Tests
+    needs: lint
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        operating-system: ${{ matrix.operating-system }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox
+  testpypipublish:
+    name: Build Test Distribution
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel --universal
+        twine check dist/*
+      env:
+        DEVBUILD: 1
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        repository_url: https://test.pypi.org/legacy/
+        user: __token__
+        password: ${{ secrets.PYPITEST_PASSWORD }}
+  pypipublish:
+    name: Build Production Distribution
+    needs: testpypipublish
+    if: github.ref == 'refs/heads/master' && startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel --universal
+        twine check dist/*
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,13 @@
 """`tokendito` is in Github: <https://github.com/dowjones/tokendito>_."""
 
 from codecs import open
+import datetime
 import os
 from os import path
 import sys
 
 from setuptools import find_packages, setup
+
 
 here = path.abspath(path.dirname(__file__))
 
@@ -21,6 +23,10 @@ with open('requirements.txt') as f:
 about = {}
 with open(os.path.join(here, 'tokendito', '__version__.py'), 'r') as f:
     exec(f.read(), about)
+
+if 'DEVBUILD' in os.environ:
+    now = datetime.datetime.now()
+    about['__version__'] = about['__version__'] + '.dev' + now.strftime('%Y%m%d%H%M%S')
 
 setup(
     name='tokendito',
@@ -57,6 +63,5 @@ setup(
     entry_points={
         'console_scripts': ['tokendito=tokendito.__main__:main'],
     },
-
     # $ pip install -e . [dev,test]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,14 @@ commands =
     flake8
     pyroma --min=10 .
 
+[gh-actions]
+python =
+    2.7: py27
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+
 [flake8]
 max-line-length = 100
 max-complexity = 8


### PR DESCRIPTION
Changing CCI for Actions allows us to run our tests on the cross product of
(supported python versions) x (supported operating systems).

This increases our test coverage from one operating system to three. It also
moves our build and publish pipeline into an automated action, provided that
the PyPI credentials have been properly configured.

1 of 2: CCI and Github Actions in parallel.