### PR TITLE
Fix URL Input Validation

### DIFF
--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -104,6 +104,20 @@ def test_set_okta_password(monkeypatch):
     assert settings.okta_password == 'pytest_patched'
 
 
+@pytest.mark.parametrize('url,expected', [
+    ('pytest_deadbeef', False),
+    ('http://acme.org/', False),
+    ('https://acme.okta.org/app/UserHome', False),
+    ('http://login.acme.org/home/amazon_aws/0123456789abcdef0123/456', False),
+    ('https://login.acme.org/home/amazon_aws/0123456789abcdef0123/456', True),
+    ('https://acme.okta.org/home/amazon_aws/0123456789abcdef0123/456?fromHome=true', True)])
+def test_validate_okta_aws_app_url(url, expected):
+    """Test whether the Okta URL functions."""
+    from tokendito import helpers
+
+    assert helpers.validate_okta_aws_app_url(input_url=url) is expected
+
+
 def test_process_environment(monkeypatch, valid_settings, invalid_settings):
     """Test whether environment variables are set in settings.*."""
     from tokendito import helpers, settings

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ python =
 [flake8]
 max-line-length = 100
 max-complexity = 8
-exclude = .git, __pycache__, .tox, venv/
+exclude = .git, __pycache__, .tox, build/, venv/
 import-order-style = google
 application-import-names = flake8
 format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s


### PR DESCRIPTION
This adds URL validation to user input before it's processed by the tool. There
may be more computationally efficient ways than this one but matching against a
well-defined regular expression works well enough.