### PR TITLE
Fix package dependency incompatibilities

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r ./requirements.txt
+docutils<0.16,>=0.10
 flake8
 flake8-colors
 flake8-docstrings
@@ -9,6 +10,7 @@ pylint>=1.8.4
 pydocstyle==3.0.0
 pyroma
 pytest
+pytest-env
 pytest-ordering
 semver
 tox

--- a/tests/functional_test.py
+++ b/tests/functional_test.py
@@ -86,7 +86,8 @@ def custom_args(request):
 @pytest.mark.run('first')
 def test_package_uninstall():
     """Uninstall tokendito if it is already installed."""
-    proc = run_process([sys.executable, '-m', 'pip', 'uninstall', '-y', 'tokendito'])
+    proc = run_process([sys.executable, '-m', 'pip', 'uninstall', '-q', '-q', '-y', 'tokendito'])
+    assert not proc['stderr']
     assert proc['exit_status'] == 0
 
 
@@ -95,12 +96,14 @@ def test_package_install():
     """Install tokendito as a python package."""
     repo_root = path.dirname(path.dirname(path.abspath(__file__)))
     proc = run_process([sys.executable, '-m', 'pip', 'install', '-e', repo_root])
+    assert not proc['stderr']
     assert proc['exit_status'] == 0
 
 
 def test_package_exists():
     """Check whether the package is installed."""
-    proc = run_process([sys.executable, '-m', 'pip', 'show', '-q', 'tokendito'])
+    proc = run_process([sys.executable, '-m', 'pip', 'show', 'tokendito'])
+    assert not proc['stderr']
     assert proc['exit_status'] == 0
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,3 +29,8 @@ exclude = .git, __pycache__, .tox, build/, venv/
 import-order-style = google
 application-import-names = flake8
 format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
+
+[pytest]
+env =
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PYTHONWARNINGS=ignore:DEPRECATION


### PR DESCRIPTION
This fixes a package depency incompatibility between requirements for
botocore and pyroma. Since requirements-dev.txt is handled before
requirements.txt is even evaluated, pip was installing a wrong version
of docutils. We now pin docutils to the version range required by boto3.

This also eliminates deprecation warning messages. In turn , this let us
test that stderr is empty and generate better error messages.