### PR TITLE
Clean up test output

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ pydocstyle==3.0.0
 pyroma
 pytest
 pytest-env
+pytest-mock
 pytest-ordering
 semver
 tox

--- a/tests/functional_test.py
+++ b/tests/functional_test.py
@@ -114,10 +114,10 @@ def test_package_exists():
 def test_version(package_version, package_regex, runnable):
     """Check if the package version is the same when running in different ways."""
     proc = run_process(runnable)
-    match = re.match(package_regex, proc['stdout'])
-    local_version = match.group('version')
     assert not proc['stderr']
     assert proc['exit_status'] == 0
+    match = re.match(package_regex, proc['stdout'])
+    local_version = match.group('version')
     assert package_version == local_version
 
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -160,7 +160,7 @@ def test_process_arguments(valid_settings, invalid_settings):
 
 @pytest.mark.skipif(sys.version_info[:2] == (3, 5),
                     reason="ConfigParser bug, see https://bugs.python.org/issue29623")
-def test_process_ini_file(tmpdir, valid_settings, invalid_settings):
+def test_process_ini_file(tmpdir, valid_settings, invalid_settings, mocker):
     """Test whether ini config elements are correctly set in settings.*."""
     from tokendito import helpers, settings
     # Create a mock config file
@@ -180,7 +180,8 @@ def test_process_ini_file(tmpdir, valid_settings, invalid_settings):
 
     # Ensure we fail if the section is not found
     with pytest.raises(SystemExit) as err:
-        helpers.process_ini_file(path, 'expected_failure')
+        mocker.patch('logging.error')
+        helpers.process_ini_file(path, 'pytest_expected_failure')
         # assert err.type == SystemExit
         assert err.value.code == 2
 


### PR DESCRIPTION
* Introduce mocker to selectively supress logger output
* Re-order functional assertion to catch bad executions early