### PR TITLE
Select role from AWS_PROFILE env variable

### DIFF
--- a/tokendito/helpers.py
+++ b/tokendito/helpers.py
@@ -189,7 +189,11 @@ def select_role_arn(role_arns, saml_xml, saml_response_string):
 
     """
     logging.debug("Select the role user wants to pick [{}]".format(role_arns))
-    if settings.role_arn is None:
+    role_names = dict((role.split("/")[-1], role) for role in role_arns)
+    if settings.aws_profile in role_names.keys():
+        selected_role = role_names[settings.aws_profile]
+        logging.debug("Using aws_profile env var for role: [{}]".format(settings.aws_profile))
+    elif settings.role_arn is None:
         selected_role = prompt_role_choices(
             role_arns, saml_xml, saml_response_string)
     elif settings.role_arn in role_arns:


### PR DESCRIPTION
When the `AWS_PROFILE` environment variable is set, use that to select the role_arn, rather than prompting the user to select a role. This addresses an issue where a user-selected role and the `AWS_PROFILE` do not match, and credentials are then saved associated to the wrong role name.

In the sample behavior, I have the `AWS_PROFILE` variable set to a role named `myawsc`, but then accidentally select `4` which is for the role `myawse` (or I simply forget I have `AWS_PROFILE` set). The credentials are obtained for account `myawc`, but are saved in the `.aws/credentials` file using the name `myawse` which can lead to much confusion.
```
export AWS_PROFILE=myawsc.okta.Admin
$ tokendito
Password:

Select your preferred MFA method and press Enter:
[0] OKTA    push
[1] OKTA    sms
[2] OKTA    token:software:totp
-> 0
Waiting for an approval from device...
Please select one of the following:

[0] djamznmyawsa arn:aws:iam::8675309:role/myawsa.okta.Admin
[1] djamznmyawsb arn:aws:iam::8675310:role/myawsb.okta.Admin
[2] djamznmyawsc arn:aws:iam::8675311:role/myawsc.okta.Admin
[3] djamznmyawsd arn:aws:iam::8675312:role/myawsd.okta.Admin
[4] djamznmyawse arn:aws:iam::8675313:role/myawse.okta.Admin
-> 4

Generated profile 'myawsc.okta.Admin' in /Users/sconzof/.aws/credentials.

Use profile to authenticate to AWS:
	aws --profile 'myawsc.okta.Admin' sts get-caller-identity
OR
	export AWS_PROFILE='myawsc.okta.Admin'

Credentials are valid until 2020-05-27 02:16:17+00:00.
```
With this PR, tokendito will recognize that the `AWS_PROFILE` variable is defined, and won't offer the user the choice to select a role. Here is a sample after applying this PR:
```
export AWS_PROFILE=myawsc.okta.Admin
$ tokendito
Password:

Select your preferred MFA method and press Enter:
[0] OKTA    push
[1] OKTA    sms
[2] OKTA    token:software:totp
-> 0
Waiting for an approval from device...

Generated profile 'myawsc.okta.Admin' in /Users/sconzof/.aws/credentials.

Use profile to authenticate to AWS:
	aws --profile 'myawsc.okta.Admin' sts get-caller-identity
OR
	export AWS_PROFILE='myawsc.okta.Admin'

Credentials are valid until 2020-05-27 02:16:17+00:00.
```
This behavior should be less confusing to the user, since they are not able to select a profile that differs from what is set in the `AWS_PROFILE` variable.