### PR TITLE
fix: split version publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,32 @@ on:
       - master
 
 jobs:
+  testpypipublish:
+    name: Build and Publish Test Distribution
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel --universal
+        twine check dist/*
+      env:
+        DEVBUILD: 1
+    - name: Publish distribution package to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPITEST_PASSWORD }}
+        repository_url: https://test.pypi.org/legacy/
   pypipublish:
     name: Build and Publish Production Distribution
     runs-on: ubuntu-latest
@@ -24,12 +50,6 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel --universal
         twine check dist/*
-    - name: Publish distribution package to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.PYPITEST_PASSWORD }}
-        repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution package to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
This allows for rolling releases to Test PyPI