### PR TITLE
chore: submit coverage reports to coveralls.io

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,18 @@ jobs:
         pip install tox tox-gh-actions
     - name: Test with tox
       run: tox
+    - name: Convert coverage to LCOV format
+      if: matrix.python-version == '3.8'
+      run: tox -e coverage
+    - name: Upload coverage in Parallel
+      if: matrix.python-version == '3.8'
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        flag-name: run-${{ matrix.os }}-${{ matrix.python-version }}
+        path-to-lcov: ${{ github.workspace }}/lcov.info
+        parallel: true
+
   auth:
     name: Authenticated Tests
     needs: test
@@ -73,3 +85,19 @@ jobs:
           MFA_RESPONSE: ${{ secrets.TOXTEST_MFA_RESPONSE }}
           OKTA_AWS_APP_URL: ${{ secrets.TOXTEST_OKTA_AWS_APP_URL }}
           ROLE_ARN: ${{ secrets.TOXTEST_ROLE_ARN }}
+      - name: Generate Coverage reports
+        run: |
+          tox -e coverage
+      - name: Upload Coverage for auth tests
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: ${{ github.workspace }}/lcov.info
+          flag-name: run-3.x-auth
+          parallel: true
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: ${{ github.workspace }}/lcov.info
+          parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+lcov.info
 
 # Translations
 *.mo

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,9 @@ Generate temporary AWS credentials via Okta.
 .. image:: https://img.shields.io/badge/OS-Mac%2C%20Windows%2C%20Linux-9cf
     :target: https://github.com/dowjones/tokendito/
 
+.. image:: https://coveralls.io/repos/github/dowjones/tokendito/badge.svg
+    :target: https://coveralls.io/github/dowjones/tokendito
+
 |
 |
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r ./requirements.txt
 black==20.8b1; python_version >= '3.6'
+coveragepy-lcov; python_version >= '3.8'
 docutils<0.16,>=0.10
 flake8
 flake8-black; python_version >= '3.6'
@@ -8,11 +9,12 @@ flake8-docstrings
 flake8-import-order>=0.9
 pep8-naming
 pexpect>=4.6.0
-pylint>=1.8.4
 pydocstyle==3.0.0
+pylint>=1.8.4
 pyotp
 pyroma
 pytest
+pytest-cov
 pytest-env
 pytest-mock
 pytest-ordering

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 skipsdist = true
-envlist = lint, py{27,35,36,37,38}, auth
+envlist = lint, py{27,35,36,37,38}, auth, coverage
 
 [testenv]
 deps = -r requirements-dev.txt
 commands =
-    py.test -v -rA -k 'unit' -s tests/
-    py.test -v -rA -k 'functional and not credentials' -s tests/
+    py.test --cov=tokendito --cov-append -v -rA -k 'unit' -s tests/
+    py.test --cov=tokendito --cov-append -v -rA -k 'functional and not credentials' -s tests/
 
 [testenv:lint]
 skip_install = true
@@ -18,7 +18,13 @@ commands =
 skip_install = true
 passenv = OKTA_* AWS_* ROLE_* MFA_*
 commands =
-    py.test -v -rA -k 'functional and credentials' -s tests/ {posargs}
+    py.test --cov=tokendito --cov-append -v -rA -k 'functional and credentials' -s tests/ {posargs}
+
+[testenv:coverage]
+skip_install = true
+commands =
+    coverage report
+    coveragepy-lcov --relative_path
 
 [gh-actions]
 python =


### PR DESCRIPTION
Submits coverage reports to coveralls.io. This will let us surface code
areas that need improvement, and eventually set a minimum coverage
target for pull requests. The LCOV conversion utility only supports
python >= 3.8, so we need to tread with care.