### PR TITLE
Change operations order

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -148,3 +148,13 @@ Design & Limitations
 * This tool does not cache and reuse Okta session IDs
 
 `Pull requests welcome <CONTRIBUTING.rst>`_!
+
+
+Configuration settings and precedence
+-------------------------------------
+
+The TOKENDITO uses credentials and configuration settings located in multiple places, such as the system or user environment variables, local configuration files, or explicitly declared on the command line as a parameter. Certain locations take precedence over others. The AWS CLI credentials and configuration settings take precedence in the following order:
+
+1) Command line options – Overrides settings in any other location. You can specify --username, --role-arn, --okta-aws-app-url, and --mfa-method as parameters on the command line.
+2) Environment variables – You can store values in your system's environment variables.
+3) CLI credentials file – The credentials and config file are updated when you run the command tokendito --configure. The credentials file is located at ~/.aws/okta_auth on Linux or macOS, or at C:/Users/USERNAME/.aws/okta_auth on Windows. This file can contain the credential details for the default profile and any named profiles.

--- a/tokendito/helpers.py
+++ b/tokendito/helpers.py
@@ -775,10 +775,10 @@ def process_options(args):
 
     # 1: read ini file (if it exists)
     process_ini_file(args.config_file, args.okta_profile)
-    # 2: override with args
-    process_arguments(args)
-    # 3: override with ENV
+    # 2: override with ENV
     process_environment()
+    # 3: override with args
+    process_arguments(args)
 
     process_okta_aws_app_url()
     # Set username and password for Okta Authentication


### PR DESCRIPTION
In this commit we change operations order to do application more logical
first, we read args from INI file, then override them with ENV variables, and then override them with CLI args
instead of 
INI, CLI, ENV