### PR TITLE
remove pyopenssl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-boto3>=1.9.0
+botocore>=1.12.36
 requests>=2.19.0
-pyOpenSSL>=18.0.0
 beautifulsoup4>=4.6.0

--- a/tokendito/aws_helpers.py
+++ b/tokendito/aws_helpers.py
@@ -12,10 +12,10 @@ import codecs
 import logging
 import sys
 
-import boto3
 from botocore import UNSIGNED
 from botocore.client import Config
 from botocore.exceptions import ClientError
+import botocore.session
 import requests
 from tokendito import helpers
 
@@ -108,8 +108,9 @@ def handle_assume_role(role_arn, provider_arn, encoded_xml, duration, default_er
     :return: AssumeRoleWithSaml API responses
     """
     logging.debug(f"Attempting session time [{duration}]")
-    client = boto3.client("sts", config=Config(signature_version=UNSIGNED))
     try:
+        session = botocore.session.get_session()
+        client = session.create_client("sts", config=Config(signature_version=UNSIGNED))
         assume_role_response = client.assume_role_with_saml(
             RoleArn=role_arn,
             PrincipalArn=provider_arn,
@@ -155,7 +156,9 @@ def ensure_keys_work(assume_role_response):
     aws_session_token = assume_role_response["Credentials"]["SessionToken"]
 
     try:
-        client = boto3.client(
+        session = botocore.session.get_session()
+
+        client = session.create_client(
             "sts",
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_key,


### PR DESCRIPTION
remove pyopenssl because of stdlib
remove lxml because it has a lot of dependencies and we need to reduce alpine docker image
remove tzlocal and configparser because we replaced it with standard library 
replace boto3 with botocore to get rid of some dependencies