### PR TITLE
Refactor logging to use an object rather than the logging module

### DIFF
--- a/tokendito/tool.py
+++ b/tokendito/tool.py
@@ -9,18 +9,21 @@ from tokendito import okta_helpers
 from tokendito import settings
 
 
+logger = logging.getLogger(__name__)
+
+
 def cli(args):
     """Tokendito retrieves AWS credentials after authenticating with Okta."""
     # Set some required initial values
     args = helpers.setup(args)
 
-    logging.debug("tokendito retrieves AWS credentials after authenticating with Okta.")
+    logger.debug("tokendito retrieves AWS credentials after authenticating with Okta.")
 
     # Collect and organize user specific information
     helpers.process_options(args)
 
     # Authenticate okta and AWS also use assumerole to assign the role
-    logging.debug("Authenticate user with Okta and AWS.")
+    logger.debug("Authenticate user with Okta and AWS.")
 
     secret_session_token = okta_helpers.authenticate_user(
         settings.okta_org, settings.okta_username, settings.okta_password


### PR DESCRIPTION
Changes the way we log from logging.level() to logger.level(). This
is a more standardized and accepted way of logging in python.

We also add timing information to the logs, together with the correct
module name and common practice logging format. E.g.

From:
```
DEBUG [helpers.py:validate_okta_aws_app_url():422]: ParseResultBytes(scheme=b'', netloc=b'', path=b'', params=b'', query=b'', fragment=b'') does not look like a valid match.
ERROR [helpers.py:process_okta_aws_app_url():523]: Okta Application URL not found, or invalid. Please check your configuration and try again.
```

To:
```
2021-09-02 11:51:35,898 tokendito.helpers [validate_okta_aws_app_url():414] - DEBUG - ParseResultBytes(scheme=b'', netloc=b'', path=b'', params=b'', query=b'', fragment=b'') does not look like a valid match.
2021-09-02 11:51:35,898 tokendito.helpers [process_okta_aws_app_url():515] - ERROR - Okta Application URL not found, or invalid. Please check your configuration and try again.
```