### PR TITLE
Fix credentials going to the incorrect configuration keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
           pip install tox
       - name: Run Authenticated tests
         run: |
-          tox -e auth
+          tox -e py310,auth
         env:
           TOKENDITO_OKTA_USERNAME: ${{ secrets.TOXTEST_OKTA_USERNAME }}
           TOKENDITO_OKTA_PASSWORD: ${{ secrets.TOXTEST_OKTA_PASSWORD }}

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -790,8 +790,8 @@ def set_local_credentials(response={}, role="default", region="us-east-1", outpu
     :return: Role name on a successful call.
     """
     try:
-        aws_access_key = response["Credentials"]["AccessKeyId"]
-        aws_secret_key = response["Credentials"]["SecretAccessKey"]
+        aws_access_key_id = response["Credentials"]["AccessKeyId"]
+        aws_secret_access_key = response["Credentials"]["SecretAccessKey"]
         aws_session_token = response["Credentials"]["SessionToken"]
     except KeyError as err:
         logger.error(f"Could not retrieve crendentials: {err}")
@@ -800,16 +800,16 @@ def set_local_credentials(response={}, role="default", region="us-east-1", outpu
     update_ini(
         profile=role,
         ini_file=config.aws["shared_credentials_file"],
-        aws_access_key=aws_access_key,
-        aws_secret_key=aws_secret_key,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
         aws_session_token=aws_session_token,
     )
 
     update_ini(
-        profile=role,
+        profile=f"profile {role}",
         ini_file=config.aws["config_file"],
-        aws_output=output,
-        aws_region=region,
+        output=output,
+        region=region,
     )
 
     return role
@@ -977,7 +977,7 @@ def process_interactive_input(config_obj):
         config_obj.okta["username"] = config_details["okta_username"]
 
     if config_obj.okta["app_url"] and not config_obj.okta["org"]:
-        config_obj["org"] = get_base_url(config_obj["app_url"])
+        config_obj.okta["org"] = get_base_url(config_obj.okta["app_url"])
         logger.debug(f"Connection string is {config_obj.okta['org']}")
 
     if config_obj.okta["password"] == "":

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist = lint, py{36,37,38,39,310}, auth, coverage
 [testenv]
 deps = -r requirements-dev.txt
 commands =
-    pytest --cov=tokendito --cov-append -v -rA -k 'unit' -s tests/
-    pytest --cov=tokendito --cov-append -v -rA -k 'functional and not credentials' -s tests/
+    pytest --cov=tokendito --cov-append -v -rA -k 'unit' -s tests/ --
+    pytest --cov=tokendito --cov-append -v -rA -k 'functional and not credentials' -s tests/ --
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
# Pull Request Template

## Description
Testing revealed that key/value pairs were being written incorrectly to configuration files

## Motivation and Context
This is required to ensure that `tokendito` can continue to generate usable credentials.

## How Has This Been Tested?
Tested manually, and through `tox`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
