### PR TITLE
Fix interactive processing.

### DIFF
--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -145,7 +145,7 @@ def test_get_interactive_config(mocker):
     # test that interactive values are handled correctly
     mocker.patch("tokendito.user.get_org_url", return_value="https://pytest")
     mocker.patch("tokendito.user.get_app_url", return_value="https://pytest")
-    ret = user.get_interactive_config(app_url="", org_url="", username="pytest")
+    ret = user.get_interactive_config(app_url=None, org_url=None, username="pytest")
     assert ret["okta_username"] == "pytest" and ret["okta_org_url"] == "https://pytest"
 
 

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -698,7 +698,7 @@ def process_interactive_input(config):
     if "okta_username" in details:
         res["okta"]["username"] = details["okta_username"]
 
-    if "password" not in config.okta:
+    if "password" not in config.okta or config.okta["password"] == "":
         logger.debug("No password set, will try to get one interactively")
         res["okta"]["password"] = get_password()
         add_sensitive_value_to_be_masked(res["okta"]["password"])
@@ -708,7 +708,7 @@ def process_interactive_input(config):
     return config_int
 
 
-def get_interactive_config(app_url="", org_url="", username=""):
+def get_interactive_config(app_url=None, org_url=None, username=""):
     """Obtain user input from the user.
 
     :return: dictionary with values
@@ -717,16 +717,17 @@ def get_interactive_config(app_url="", org_url="", username=""):
     details = {}
 
     # We need either one of these two:
-    while org_url == "" and app_url == "":
+    while org_url is None and app_url is None:
         print("\nPlease enter either your Organization URL, a tile (app) URL, or both.")
         org_url = get_org_url()
         app_url = get_app_url()
+
     while username == "":
         username = get_username()
 
-    if org_url != "":
+    if org_url is not None:
         details["okta_org_url"] = org_url
-    if app_url != "":
+    if app_url is not None:
         details["okta_app_url"] = app_url
     details["okta_username"] = username
 


### PR DESCRIPTION
# Pull Request

## Description
Fix an issue where if there is no configuration file, and Tokendito ran in interactive mode, it would not prompt the user for all the necessary information to log them into Okta.

## How Has This Been Tested?
`tox`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
