### PR TITLE
Extend configuration capabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,5 @@ exclude_lines = [
     "if __package__ is None:",
     "logger.debug",
     "pragma: no cover",
+    "print..Invalid input, try again...",
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 skip_install = true
 passenv = TOKENDITO_*
 commands =
-    pytest --cov=tokendito --cov-append -v -rA -k 'functional and credentials' -s tests/ {posargs}
+    pytest --cov=tokendito --cov-append -v -rA -k 'functional and (config or credentials)' -s tests/ {posargs}
 
 [testenv:coverage]
 skip_install = true


### PR DESCRIPTION
## Description

Our `--configure` flag used to allow only interactive input. It can now be also used to convert additional configuration elements and write them out to disk after validation.

## How Has This Been Tested?
locally with `tox`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
