### PR TITLE
Deprecate Python 3.6, to keep inline with supported versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Generate temporary AWS credentials via Okta.
 .. image:: https://github.com/dowjones/tokendito/workflows/Lint%20and%20Test/badge.svg
     :target: https://github.com/dowjones/tokendito/actions
 
-.. image:: https://img.shields.io/badge/python-3.6%2C%203.7%2C%203.8%2C%203.9%2C%203.10-blueviolet
+.. image:: https://img.shields.io/badge/python-3.7%2C%203.8%2C%203.9%2C%203.10%2C%203.11-blueviolet
     :target: https://pypi.org/project/tokendito/
 
 .. image:: https://github.com/dowjones/tokendito/workflows/Woke/badge.svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310', 'py311']
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 
 [tool.coverage.report]
 exclude_lines = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4>=4.6.0
 botocore>=1.12.36
-platformdirs>=2.4.0 # This can be bumped after Python 3.6 is deprecated.
+platformdirs>=2.5.4
 requests>=2.19.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = lint, py{36,37,38,39,310,311}, auth, coverage
+envlist = lint, py{37,38,39,310,311}, auth, coverage
 
 [testenv]
 deps = -r requirements-dev.txt
@@ -30,11 +30,11 @@ commands =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
## Description
Deprecate Python 3.6

## Motivation and Context
This is to keep inline with the official Python-supported versions list.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
