### PR TITLE
Support Push + Number Challenge

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,9 +2,13 @@ Tokendito is written and maintained by Cloud Security and Engineering at
 Dow Jones, and various contributors:
 
 ## Dow Jones Cloud Security and Engineering
+
 * Sydney Sweeney 
+* Jean-Pierre Sevigny
 * Nico Halpern 
+
 ## Patches and more 
+
 * Kuber Kaul 
 * Steve Stevenson 
 * Roman Sluzhynskyy 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ The following changes are part of this release:
 - Automatically discover AWS URLs.
 - Fix authentication with DUO.
 - Add support for setting the logging level via both the INI file and ENV vars.
-- Add support for Python 3.9 and 3.10.
+- Add support for Python 3.9, 3.10, and 3.11.
 - And many fixes.
 
-Consult [additional notes](docs/README.md) for how to use tokendito. 
+Consult [additional notes](https://github.com/dowjones/tokendito/blob/main/docs/README.md) for how to use tokendito. 
 
 ## Requirements
 
@@ -53,9 +53,10 @@ pip or pip3.
 3.  Run `tokendito`.
 
 **NOTE**: Advanced users may shorten the `tokendito` interaction to a [single
-command](docs/README.md#single-command-usage).
+command](https://github.com/dowjones/tokendito/blob/main/docs/README.md#single-command-usage).
 
 Have multiple Okta tiles to switch between? View our [multi-tile
-guide](docs/README.md#multi-tile-guide).
+guide](https://github.com/dowjones/tokendito/blob/main/docs/README.md#multi-tile-guide).
 
-### Tips, tricks, troubleshooting, examples, and more docs are [here](docs/README.md)! Also, [contributions are welcome](docs/CONTRIBUTING.md)!
+### Tips, tricks, troubleshooting, examples, and more docs are [here]()https://github.com/dowjones/tokendito/blob/main/docs/README.md!
+[Contributions are welcome](https://github.com/dowjones/tokendito/blob/main/docs/CONTRIBUTING.md)!

--- a/tokendito/__init__.py
+++ b/tokendito/__init__.py
@@ -8,7 +8,7 @@ import sys
 
 from platformdirs import user_config_dir
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __title__ = "tokendito"
 __description__ = "Get AWS STS tokens from Okta SSO"
 __long_description_content_type__ = "text/markdown"


### PR DESCRIPTION
## Description
This introduces the ability to display the numerical challenge that can be part of a `push` challenge.

## Related Issue
This addresses the lack of functionality referenced in #107 

## Motivation and Context
Okta introduced a "Number Challenge" feature that can be combined with a `push` to enhance security. This may be present in all AUTHn calls, some, or none, depending on the configuration for the Okta Organization.

## How Has This Been Tested?
Tested locally with `tox` and manually against a non-production Okta instance

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
