### PR TITLE
Add interactive prompt for AWS profile name

### DIFF
--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1176,6 +1176,7 @@ def test_process_interactive_input(mocker):
     "role_name,user_input,expected",
     [
         ("", "", ""),
+        ("", "different_name", "different_name")
         ("role_name", "", "role_name"),
         ("role_name", "different_name", "different_name"),
         ("role_name", "role_name", "role_name"),

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1181,7 +1181,7 @@ def test_process_interactive_input(mocker):
     ],
 )
 def test_get_profile_name(mocker, role_name, user_input, expected):
-    """Test get tile URL."""
+    """Test get profile name."""
     from tokendito import user
 
     mocker.patch("tokendito.user.input", return_value=user_input)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1175,9 +1175,10 @@ def test_process_interactive_input(mocker):
 @pytest.mark.parametrize(
     "role_name,user_input,expected",
     [
+        ("", "", ""),
         ("role_name", "", "role_name"),
         ("role_name", "different_name", "different_name"),
-        ("role_name", "role_name", "different_name"),
+        ("role_name", "role_name", "role_name"),
     ],
 )
 def test_get_profile_name(mocker, role_name, user_input, expected):

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1193,11 +1193,12 @@ def test_get_profile_name(mocker, default, submit, expected):
 def test_get_profile_name_invalid_input(monkeypatch):
     """Test reprompting the AWS profile name form user on invalid input."""
     from tokendito import user
+
     # provided inputs
     inputs = iter(["_this_is_invalid", "str with space", "1StartsWithNum", "valid"])
 
     # using lambda statement for mocking
-    monkeypatch.setattr('builtins.input', lambda name: next(inputs))
+    monkeypatch.setattr("builtins.input", lambda name: next(inputs))
 
     assert user.get_profile_name("role_name") == "valid"
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1176,7 +1176,7 @@ def test_process_interactive_input(mocker):
     "role_name,user_input,expected",
     [
         ("", "", ""),
-        ("", "different_name", "different_name")
+        ("", "different_name", "different_name"),
         ("role_name", "", "role_name"),
         ("role_name", "different_name", "different_name"),
         ("role_name", "role_name", "role_name"),

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1182,15 +1182,15 @@ def test_process_interactive_input(mocker):
         ("role_name", "role_name", "role_name"),
     ],
 )
-def test_get_profile_name(mocker, default, submit, expected):
+def test_get_interactive_profile_name(mocker, default, submit, expected):
     """Test getting the AWS profile name form user input."""
     from tokendito import user
 
     mocker.patch("tokendito.user.input", return_value=submit)
-    assert user.get_profile_name(default) == expected
+    assert user.get_interactive_profile_name(default) == expected
 
 
-def test_get_profile_name_invalid_input(monkeypatch):
+def test_get_interactive_profile_name_invalid_input(monkeypatch):
     """Test reprompting the AWS profile name form user on invalid input."""
     from tokendito import user
 
@@ -1200,7 +1200,7 @@ def test_get_profile_name_invalid_input(monkeypatch):
     # using lambda statement for mocking
     monkeypatch.setattr("builtins.input", lambda name: next(inputs))
 
-    assert user.get_profile_name("role_name") == "valid"
+    assert user.get_interactive_profile_name("role_name") == "valid"
 
 
 @pytest.mark.parametrize(
@@ -1209,18 +1209,18 @@ def test_get_profile_name_invalid_input(monkeypatch):
         ("pytest", None, "pytest"),
         ("pytest", "deadbeef", "pytest"),
         ("pytest", 0xDEADBEEF, "pytest"),
-        (None, None, "default"),
-        (None, "", "default"),
-        (None, 0xDEADBEEF, str(0xDEADBEEF)),
+        (None, "user_input", "user_input"),
     ],
 )
-def test_set_profile_name(value, submit, expected):
+def test_set_profile_name(mocker, value, submit, expected):
     """Test setting the AWS Profile name."""
     from tokendito import user, Config
 
     pytest_config = Config(aws=dict(profile=value))
 
-    ret = user.set_profile_name(pytest_config, submit)
+    mocker.patch("tokendito.user.get_interactive_profile_name", return_value=submit)
+
+    ret = user.set_profile_name(pytest_config, "role_name")
     assert ret.aws["profile"] == expected
 
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1173,7 +1173,7 @@ def test_process_interactive_input(mocker):
 
 
 @pytest.mark.parametrize(
-    "role_name,user_input,expected",
+    "default,submit,expected",
     [
         ("", "", ""),
         ("", "different_name", "different_name"),
@@ -1182,12 +1182,24 @@ def test_process_interactive_input(mocker):
         ("role_name", "role_name", "role_name"),
     ],
 )
-def test_get_profile_name(mocker, role_name, user_input, expected):
-    """Test get profile name."""
+def test_get_profile_name(mocker, default, submit, expected):
+    """Test getting the AWS profile name form user input."""
     from tokendito import user
 
-    mocker.patch("tokendito.user.input", return_value=user_input)
-    assert user.get_profile_name(role_name) == expected
+    mocker.patch("tokendito.user.input", return_value=submit)
+    assert user.get_profile_name(default) == expected
+
+
+def test_get_profile_name_invalid_input(monkeypatch):
+    """Test reprompting the AWS profile name form user on invalid input."""
+    from tokendito import user
+    # provided inputs
+    inputs = iter(["_this_is_invalid", "str with space", "1StartsWithNum", "valid"])
+
+    # using lambda statement for mocking
+    monkeypatch.setattr('builtins.input', lambda name: next(inputs))
+
+    assert user.get_profile_name("role_name") == "valid"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1173,6 +1173,22 @@ def test_process_interactive_input(mocker):
 
 
 @pytest.mark.parametrize(
+    "role_name,user_input,expected",
+    [
+        ("role_name", "", "role_name"),
+        ("role_name", "different_name", "different_name"),
+        ("role_name", "role_name", "different_name"),
+    ],
+)
+def test_get_profile_name(mocker, role_name, user_input, expected):
+    """Test get tile URL."""
+    from tokendito import user
+
+    mocker.patch("tokendito.user.input", return_value=user_input)
+    assert user.get_profile_name(role_name) == expected
+
+
+@pytest.mark.parametrize(
     "value,submit,expected",
     [
         ("pytest", None, "pytest"),
@@ -1183,13 +1199,13 @@ def test_process_interactive_input(mocker):
         (None, 0xDEADBEEF, str(0xDEADBEEF)),
     ],
 )
-def test_set_role_name(value, submit, expected):
-    """Test setting the AWS Role (profile) name."""
+def test_set_profile_name(value, submit, expected):
+    """Test setting the AWS Profile name."""
     from tokendito import user, Config
 
     pytest_config = Config(aws=dict(profile=value))
 
-    ret = user.set_role_name(pytest_config, submit)
+    ret = user.set_profile_name(pytest_config, submit)
     assert ret.aws["profile"] == expected
 
 

--- a/tokendito/tool.py
+++ b/tokendito/tool.py
@@ -63,7 +63,11 @@ def cli(args):
         )
         sys.exit(1)
 
-    user.set_role_name(config, role_name)
+    profile_name = config.aws["profile"]
+    if profile_name is None or profile_name == "":
+        profile_name = user.get_profile_name(role_name)
+
+    user.set_profile_name(config, profile_name)
 
     user.set_local_credentials(
         response=role_response,

--- a/tokendito/tool.py
+++ b/tokendito/tool.py
@@ -63,11 +63,7 @@ def cli(args):
         )
         sys.exit(1)
 
-    profile_name = config.aws["profile"]
-    if profile_name is None or profile_name == "":
-        profile_name = user.get_profile_name(role_name)
-
-    user.set_profile_name(config, profile_name)
+    user.set_profile_name(config, role_name)
 
     user.set_local_credentials(
         response=role_response,

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -879,7 +879,7 @@ def get_profile_name(name):
         user_data = user_data.strip()
         if user_data == "":
             break
-        if len(user_data.split()) == 1:
+        if re.fullmatch("[a-zA-Z][a-zA-Z0-9_-]*", user_data):
             res = user_data
         else:
             print("Invalid input, try again.")

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -864,19 +864,19 @@ def get_password():
     return res
 
 
-def get_profile_name(name):
+def get_profile_name(default):
     """Get AWS profile name from user.
 
-    :return: string with sanitized value, or the empty string.
+    :return: string with sanitized value, or the default string.
     """
-    message = f"Enter a profile name or leave blank to use '{name}': "
+    message = f"Enter a profile name or leave blank to use '{default}': "
     res = ""
 
     while res == "":
         user_data = get_input(prompt=message)
         user_data = user_data.strip()
         if user_data == "":
-            break
+            res = default
         if re.fullmatch("[a-zA-Z][a-zA-Z0-9_-]*", user_data):
             res = user_data
         else:

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -877,6 +877,7 @@ def get_profile_name(default):
         user_data = user_data.strip()
         if user_data == "":
             res = default
+            break
         if re.fullmatch("[a-zA-Z][a-zA-Z0-9_-]*", user_data):
             res = user_data
         else:

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -869,9 +869,7 @@ def get_profile_name(name):
 
     :return: string with sanitized value, or the empty string.
     """
-    message = (
-        f"Enter a profile name or leave blank to use '{name}': "
-    )
+    message = f"Enter a profile name or leave blank to use '{name}': "
     res = ""
 
     while res == "":

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -864,7 +864,7 @@ def get_password():
     return res
 
 
-def get_profile_name(default):
+def get_interactive_profile_name(default):
     """Get AWS profile name from user.
 
     :return: string with sanitized value, or the default string.
@@ -886,17 +886,15 @@ def get_profile_name(default):
     return res
 
 
-def set_profile_name(config_obj, name):
+def set_profile_name(config_obj, role_name):
     """Set AWS Role alias name based on user preferences.
 
     :param config: Config object.
-    :param name: Role name. Defaults to the string "default"
+    :param role_name: Role name.
     :return: Config object.
     """
-    if name is None or name == "":
-        name = "default"
-    if config_obj.aws["profile"] is None:
-        config_obj.aws["profile"] = str(name)
+    if config_obj.aws["profile"] is None or config_obj.aws["profile"] == "":
+        config_obj.aws["profile"] = get_interactive_profile_name(role_name)
 
     return config_obj
 

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -864,7 +864,30 @@ def get_password():
     return res
 
 
-def set_role_name(config_obj, name):
+def get_profile_name(name):
+    """Get AWS profile name from user.
+
+    :return: string with sanitized value, or the empty string.
+    """
+    message = (
+        f"Enter a profile name or leave blank to use '{name}': "
+    )
+    res = ""
+
+    while res == "":
+        user_data = get_input(prompt=message)
+        user_data = user_data.strip()
+        if user_data == "":
+            break
+        if len(user_data.split()) == 1:
+            res = user_data
+        else:
+            print("Invalid input, try again.")
+    logger.debug(f"Profile name is: {res}")
+    return res
+
+
+def set_profile_name(config_obj, name):
     """Set AWS Role alias name based on user preferences.
 
     :param config: Config object.


### PR DESCRIPTION
## Description
Ask the user what name to give the AWS credential profile after the role is selected.

## Related Issue
[#110](https://github.com/dowjones/tokendito/issues/110)

## Motivation and Context
Currently the AWS profile is defaulted to the IAM role name but this is not specific enough for my needs as I have access to multiple accounts with matching role names. I prefix my profile names with the AWS account name so that I can have confidence that I am working in the correct environment.

## How Has This Been Tested?
I ran through the interactive prompts and the output worked as expected.  I then tested the local profile and was able to successfully execute commands with the AWS cli using the generated credentials.  More testing should be done to validate expected behavior when environment variables, saved config files, or command line options which should exclude the prompt from being displayed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes