### PR TITLE
Feature/set perms on run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !LICENSE.txt
 !README.md
 !tokendito/*.py
+!docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,5 @@ WORKDIR /app
 
 # Creates a non-root user with an explicit UID and adds permission to access the /app folder
 RUN adduser -u 5678 --disabled-password --gecos "" tokendito && chown -R tokendito /app
-USER tokendito
 
-ENTRYPOINT ["python", "tokendito/tokendito.py"]
+ENTRYPOINT [ "/app/docker-entrypoint.sh" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/ash -ex
+#!/bin/ash -e
 
 chown tokendito:tokendito /home/tokendito/.aws/config /home/tokendito/.aws/credentials /home/tokendito/.config/tokendito/tokendito.ini
 su tokendito -c "python tokendito/tokendito.py $*"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/ash -ex
+
+chown tokendito:tokendito /home/tokendito/.aws/config /home/tokendito/.aws/credentials /home/tokendito/.config/tokendito/tokendito.ini
+su tokendito -c "python tokendito/tokendito.py $*"
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/ash -e
 
-chown tokendito:tokendito /home/tokendito/.aws/config /home/tokendito/.aws/credentials /home/tokendito/.config/tokendito/tokendito.ini
+files="/home/tokendito/.aws/config /home/tokendito/.aws/credentials /home/tokendito/.config/tokendito/tokendito.ini"
+stat -c "chown %u:%g %n" $files > /tmp/$$.restore
+chown tokendito:tokendito $files
 su tokendito -c "python tokendito/tokendito.py $*"
-
+. /tmp/$$.restore


### PR DESCRIPTION
## Description
Moved user id setting from build time to runtime in order to set writable permissions on config files

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
