### PR TITLE
Fix issue with SAML document without assertions

### DIFF
--- a/tokendito/__init__.py
+++ b/tokendito/__init__.py
@@ -8,7 +8,7 @@ import sys
 
 from platformdirs import user_config_dir
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __title__ = "tokendito"
 __description__ = "Get AWS STS tokens from Okta SSO"
 __long_description_content_type__ = "text/markdown"

--- a/tokendito/aws.py
+++ b/tokendito/aws.py
@@ -204,6 +204,9 @@ def select_assumeable_role(tiles):
     authenticated_tiles = {}
     for url, saml_response, saml, label in tiles:
         roles_and_providers = user.extract_arns(saml)
+        if not roles_and_providers:
+            logger.warning(f"Skipping {url}, no valid roles or tile is misconfigured")
+            continue
         authenticated_tiles[url] = {
             "roles": list(roles_and_providers.keys()),
             "saml": saml,
@@ -211,6 +214,10 @@ def select_assumeable_role(tiles):
             "roles_and_providers": roles_and_providers,
             "label": label,
         }
+
+    if not authenticated_tiles:
+        logger.error("No roles found. Please check with your Okta admin.")
+        sys.exit(1)
 
     role_arn, _id = user.select_role_arn(authenticated_tiles)
     role_name = role_arn.split("/")[-1]

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -455,20 +455,18 @@ def extract_arns(saml):
     """
     logger.debug("Decode response string as a SAML decoded value.")
 
+    roles_and_providers = {}
     arn_regex = ">(arn:aws:iam::.*?,arn:aws:iam::.*?)<"
 
     # find all provider and role pairs.
     arns = re.findall(arn_regex, saml)
-
-    if len(arns) == 0:
-        logger.error("No IAM roles found in SAML response.")
-        logger.debug(arns)
-        sys.exit(2)
+    logger.debug(f"found ARNs: {arns}")
 
     # stuff into dict, role is dict key.
-    roles_and_providers = {i.split(",")[1]: i.split(",")[0] for i in arns}
+    if arns:
+        roles_and_providers = {i.split(",")[1]: i.split(",")[0] for i in arns}
 
-    logger.debug(f"Collected ARNs: {json.dumps(roles_and_providers)}")
+    logger.debug(f"Collected ARNs: {roles_and_providers}")
 
     return roles_and_providers
 


### PR DESCRIPTION
## Description
Fix issue with SAML document without assertions

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fixes a problem where a misconfigured tile could break scanning for
all roles. This small change skips tiles that do not have any roles,
and exits gracefully if no roles are available at all.

## How Has This Been Tested?
locally, and with `tox`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes