### PR TITLE
Fix: IWA logins should be treated as native Okta auth

### DIFF
--- a/tests/unit/test_okta.py
+++ b/tests/unit/test_okta.py
@@ -303,6 +303,7 @@ def test_push_approval(mocker, return_value, side_effect, expected):
         ({}, False),
         (None, False),
         ({"type": "OKTA"}, True),
+        ({"type": "IWA"}, True),
         ({"type": "SAML2"}, False),
     ],
 )

--- a/tokendito/__init__.py
+++ b/tokendito/__init__.py
@@ -1,7 +1,7 @@
 # vim: set filetype=python ts=4 sw=4
 # -*- coding: utf-8 -*-
 """Tokendito module initialization."""
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 __title__ = "tokendito"
 __description__ = "Get AWS STS tokens from Okta SSO"
 __long_description_content_type__ = "text/markdown"

--- a/tokendito/okta.py
+++ b/tokendito/okta.py
@@ -686,7 +686,9 @@ def idp_authenticate(config):
         # which we then put in our session cookies
         create_authn_cookies(config.okta["org"], session_token)
     else:
-        logger.error(f"{auth_properties['type']} login via IdP Discovery is not curretly supported")
+        logger.error(
+            f"{auth_properties['type']} login via IdP Discovery is not currently supported"
+        )
         sys.exit(1)
 
 
@@ -850,8 +852,10 @@ def local_authentication_enabled(auth_properties):
     :param auth_properties: auth_properties dict
     :return: True if this is the place to authenticate, False otherwise.
     """
+    # IWA (https://help.okta.com/en-us/content/topics/directory/ad-iwa-learn.htm)
+    # should be treated as local authentication
     try:
-        if auth_properties["type"] == "OKTA":
+        if auth_properties["type"] == "OKTA" or auth_properties["type"] == "IWA":
             return True
     except (TypeError, KeyError):
         pass


### PR DESCRIPTION
## Description
Treat IWA access as if it were native Okta authentication


## How Has This Been Tested?
Locally, and live with an IWA enabled Okta policy.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes