### PR TITLE
add refreshed_at to allow checking if credentials need refreshed

### DIFF
--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -75,6 +75,7 @@ def cmd_interface(args):
             )
 
     # get authentication and authorization cookies from okta
+    refreshed_at = str(int(time.time()))
     okta.access_control(config)
     logger.debug(
         f"""
@@ -107,6 +108,7 @@ def cmd_interface(args):
         role=config.aws["profile"],
         region=config.aws["region"],
         output=config.aws["output"],
+        refreshed_at=refreshed_at,
     )
 
     device_token = HTTP_client.get_device_token()
@@ -1023,13 +1025,16 @@ def update_device_token(config):
     logger.info(f"Updated {ini_file} with profile {profile}")
 
 
-def set_local_credentials(response={}, role="default", region="us-east-1", output="json"):
+def set_local_credentials(
+    response={}, role="default", region="us-east-1", output="json", refreshed_at=0
+):
     """Write to local files to insert credentials.
 
     :param response: AWS AssumeRoleWithSaml response
     :param role: the name of the assumed role, used for local profile
     :param region: configured region for aws credential profile
     :param output: configured datatype for aws cli output
+    :param refreshed_at: the time that the okta credentials were refreshed
     :return: Role name on a successful call.
     """
     try:
@@ -1046,6 +1051,7 @@ def set_local_credentials(response={}, role="default", region="us-east-1", outpu
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         aws_session_token=aws_session_token,
+        refreshed_at=refreshed_at,
     )
 
     update_ini(


### PR DESCRIPTION
## Description
Add `refreshed_at` into the credentials file to be able to recognize when we need to re-authenticate the credentials.

## Motivation and Context
I wrote in functionality for the ML team at Move, inc to write this into the credentials file and check if it's been over 8 hours. If less than 8 hours, a refresh doesn't need to take place and the current credentials can be used. This was something `aws-refresh` had and stuck into the `config` file, but it makes more sense with the code we were using to stick it into the `credentials` file (and I think the same for your code base).

This isn't the full code I wrote as I wasn't sure the logic to check for refreshes every X hours was desired to be built-in to this or not, but I pasted it below since it is super simple. It could be added easily to check if a refresh needs to occur for those credentials. I set ours to 8 hours as that was my understanding of our okta credential expiration for dow jones. Since this is a public package, that should probably be the default with the ability to change it through the cli args.

```python
def _expired_aws_credentials(credentials_path: str, account: str, role: str, expired_hours: int) -> bool:
    config = configparser.ConfigParser()
    config.read(credentials_path)

    refreshed_at = config.get(f"opcity-{account}-{role}", "refreshed_at", fallback=None)

    # None means profile hasn't been used and needs refreshed or checks if current time is more than hours to expiry of
    # the refreshed time
    return (refreshed_at is None) or ((int(time.time()) - int(refreshed_at)) > expired_hours * 60 * 60)
```

## How Has This Been Tested?
We have been using this for about 3 weeks now with no issues. I didn't build the docker and test myself yet though. Depending if the other code to check if the refresh is desired then I can properly test it.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
   - I can do this, but just checking what is desired here 
- [ ] New and existing unit tests pass locally with my changes
   - Will need to check this later 
