### PR TITLE
feat: Add support for optional profile expiration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ tokendito --profile engineer
 usage: tokendito [-h] [--version] [--configure] [--username OKTA_USERNAME] [--password OKTA_PASSWORD] [--profile USER_CONFIG_PROFILE] [--config-file USER_CONFIG_FILE]
                  [--loglevel {DEBUG,INFO,WARN,ERROR}] [--log-output-file USER_LOG_OUTPUT_FILE] [--aws-config-file AWS_CONFIG_FILE] [--aws-output AWS_OUTPUT]
                  [--aws-profile AWS_PROFILE] [--aws-region AWS_REGION] [--aws-role-arn AWS_ROLE_ARN] [--aws-shared-credentials-file AWS_SHARED_CREDENTIALS_FILE]
-                 [--okta-org OKTA_ORG | --okta-tile OKTA_TILE] [--okta-mfa OKTA_MFA] [--okta-mfa-response OKTA_MFA_RESPONSE] [--use-device-token] [--quiet]
+                 [--okta-org OKTA_ORG | --okta-tile OKTA_TILE] [--okta-mfa OKTA_MFA] [--okta-mfa-response OKTA_MFA_RESPONSE] [--use-device-token] [--use-profile-expiration] [--quiet]
 
 Gets an STS token to use with the AWS CLI and SDK.
 
@@ -115,6 +115,8 @@ options:
   --okta-mfa-response OKTA_MFA_RESPONSE
                         Sets the MFA response to a challenge
   --use-device-token    Use device token across sessions
+  --use-profile-expiration
+                        Use profile expiration to bypass re-authenticating
   --quiet               Suppress output
 ```
 
@@ -157,6 +159,7 @@ The following table lists the environment variable and user configuration entry 
 | `--okta-mfa` | `TOKENDITO_OKTA_MFA`        | `okta_mfa` |
 | `--okta-mfa-response` | `TOKENDITO_OKTA_MFA_RESPONSE`        | `okta_mfa_response` |
 | `--use-device-token` | `TOKENDITO_USER_USE_DEVICE_TOKEN`        | `user_use_device_token` |
+| `--use-profile-expiration` | `TOKENDITO_USER_USE_PROFILE_EXPIRATION`        | `user_use_profile_expiration` |
 | `--quiet` | `TOKENDITO_USER_QUIET`        | `quiet` |
 
 # Configuration file location

--- a/tokendito/config.py
+++ b/tokendito/config.py
@@ -30,6 +30,7 @@ class Config(object):
             loglevel="INFO",
             log_output_file="",
             use_device_token=False,
+            use_profile_expiration=False,
             mask_items=[],
             quiet=False,
         ),
@@ -50,6 +51,7 @@ class Config(object):
             tile=None,
             org=None,
             device_token=None,
+            profile_expiration=None,
         ),
     )
 

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -5,7 +5,7 @@ import argparse
 import builtins
 import codecs
 import configparser
-from datetime import timezone
+from datetime import datetime, timezone
 from getpass import getpass
 import json
 import logging
@@ -64,6 +64,8 @@ def cmd_interface(args):
         )
         sys.exit(1)
 
+    check_profile_expiration(config)
+
     if config.user["use_device_token"]:
         device_token = config.okta["device_token"]
         if device_token:
@@ -109,11 +111,7 @@ def cmd_interface(args):
         output=config.aws["output"],
     )
 
-    device_token = HTTP_client.get_device_token()
-    if config.user["use_device_token"] and device_token:
-        logger.info(f"Saving device token to config profile {args.user_config_profile}")
-        config.okta["device_token"] = device_token
-        update_device_token(config)
+    update_profile(config, role_response)
 
     display_selected_role(profile_name=config.aws["profile"], role_response=role_response)
 
@@ -234,6 +232,13 @@ def parse_cli_args(args):
         action="store_true",
         default=False,
         help="Use device token across sessions",
+    )
+    parser.add_argument(
+        "--use-profile-expiration",
+        dest="user_use_profile_expiration",
+        action="store_true",
+        default=False,
+        help="Use profile expiration to bypass re-authenticating",
     )
     parser.add_argument(
         "--quiet",
@@ -517,6 +522,65 @@ def prompt_role_choices(aut_tiles):
     return selected_role
 
 
+def get_role_expiration(role_response={}):
+    """Get the expiration from the role response.
+
+    :param role_response: Assume Role response dict
+    :return expiration
+    """
+    try:
+        return role_response["Credentials"]["Expiration"]
+    except (KeyError, TypeError) as err:
+        logger.error(f"Could not retrieve expiration: {err}")
+        sys.exit(1)
+
+
+def check_profile_expiration(config):
+    """Check profile expiration and exit if still valid.
+
+    :param config: Config object
+    """
+    if not config.user["use_profile_expiration"]:
+        return
+
+    profile = config.aws["profile"]
+
+    profile_expiration_str = config.okta["profile_expiration"]
+    if not profile_expiration_str:
+        logger.warning(f"Expiration unavailable for config profile {profile}. ")
+        return
+
+    profile_expiration = datetime.fromisoformat(profile_expiration_str)
+    now = datetime.now(timezone.utc)
+
+    if now < profile_expiration:
+        logger.info(f"Expiration for config profile {profile} is still valid: {profile_expiration}")
+        sys.exit(0)
+    else:
+        logger.warning(
+            f"Expiration for config profile {profile} is no longer valid: {profile_expiration}"
+        )
+
+
+def update_profile(config, role_response={}):
+    """Update profile with device token and expiration if needed.
+
+    :param config: Config object
+    :param role_response: Assume Role response dict
+    """
+    device_token = HTTP_client.get_device_token()
+    if config.user["use_device_token"] and device_token:
+        logger.info(f"Saving device token to config profile {config.aws['profile']}")
+        config.okta["device_token"] = device_token
+        update_profile_device_token(config)
+
+    role_expiration = get_role_expiration(role_response)
+    if config.user["use_profile_expiration"] and role_expiration:
+        logger.info(f"Saving expiration to config profile {config.aws['profile']}")
+        config.okta["profile_expiration"] = role_expiration
+        update_profile_expiration(config)
+
+
 def display_selected_role(profile_name="", role_response={}):
     """Print details about how to assume role.
 
@@ -525,13 +589,8 @@ def display_selected_role(profile_name="", role_response={}):
     :return: message displayed.
 
     """
-    try:
-        expiration_time = role_response["Credentials"]["Expiration"]
-    except (KeyError, TypeError) as err:
-        logger.error(f"Could not retrieve expiration time: {err}")
-        sys.exit(1)
-
-    expiration_time_local = utc_to_local(expiration_time)
+    role_expiration = get_role_expiration(role_response)
+    role_expiration_local = utc_to_local(role_expiration)
     msg = (
         f"\nGenerated profile '{profile_name}' in "
         f"{config.aws['shared_credentials_file']}.\n"
@@ -539,7 +598,7 @@ def display_selected_role(profile_name="", role_response={}):
         f"aws --profile '{profile_name}' sts get-caller-identity"
         "\nOR\n\t"
         f"export AWS_PROFILE='{profile_name}'\n\n"
-        f"Credentials are valid until {expiration_time} ({expiration_time_local})."
+        f"Credentials are valid until {role_expiration} ({role_expiration_local})."
     )
 
     print(msg)
@@ -775,7 +834,7 @@ def process_environment(prefix="tokendito"):
 
 def process_interactive_input(config, skip_password=False):
     """
-    Request input interactively interactively for elements that are not proesent.
+    Request input interactively interactively for elements that are not present.
 
     :param config: Config object with some values set.
     :param skip_password: Whether or not ask the user for a password.
@@ -1002,7 +1061,7 @@ def update_configuration(config):
     logger.info(f"Updated {ini_file} with profile {profile}")
 
 
-def update_device_token(config):
+def update_profile_device_token(config):
     """Update configuration file on local system with device token.
 
     :param config: the current configuration
@@ -1017,6 +1076,27 @@ def update_device_token(config):
     # will be written out to disk
     if "device_token" in config.okta and config.okta["device_token"] is not None:
         contents["okta_device_token"] = config.okta["device_token"]
+
+    logger.debug(f"Adding {contents} to config file.")
+    update_ini(profile=profile, ini_file=ini_file, **contents)
+    logger.info(f"Updated {ini_file} with profile {profile}")
+
+
+def update_profile_expiration(config):
+    """Update configuration file on local system with profile expiration.
+
+    :param config: the current configuration
+    :return: None
+    """
+    logger.debug("Update configuration file on local system with profile expiration.")
+    ini_file = config.user["config_file"]
+    profile = config.user["config_profile"]
+
+    contents = {}
+    # Copy relevant parts of the configuration into an dictionary that
+    # will be written out to disk
+    if "profile_expiration" in config.okta and config.okta["profile_expiration"] is not None:
+        contents["okta_profile_expiration"] = config.okta["profile_expiration"]
 
     logger.debug(f"Adding {contents} to config file.")
     update_ini(profile=profile, ini_file=ini_file, **contents)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
These changes add optional support for profile expiration checking. When enabled with the `--use-profile-expiration` option, `tokendito` will store the expiration in each profile. Subsequent authentication requests will then check the expiration to see if it's still valid and bypass the need to re-authenticate.

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This reduces the friction for our engineering teams when they need to script the use of `tokendito` and MFA is in play.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Running without the new option
- Running with the new option and a clean INI file
- Running with the new option and an INI file with expiration values

Example output:
```shell
# Without profile expiration set
❯ tokendito --use-profile-expiration--profile test_profile --aws-profile test_profile --config-file ./test-tokendito.ini
Organization username. E.g. jane.doe@acme.com: xxxxx.xxxxx
Password:
2023-12-13 10:59:21,642 WARNING |tokendito.user check_profile_expiration():550| Expiration unavailable for config profile test-profile.
…

# With profile expiration in the future set
❯ tokendito --use-profile-expiration--profile test_profile --aws-profile test_profile --config-file ./test-tokendito.ini
Organization username. E.g. jane.doe@acme.com: xxxxx.xxxxx
Password:
2023-12-13 10:57:18,126 INFO |tokendito.user check_profile_expiration():557| Expiration for config profile test-profile is still valid: 2023-12-13 23:17:10+00:00

# With profile expiration in the past set
❯ tokendito --use-profile-expiration--profile test_profile --aws-profile test_profile --config-file ./test-tokendito.ini
Organization username. E.g. jane.doe@acme.com: xxxxx.xxxxx
Password:
2023-12-13 11:02:24,429 WARNING |tokendito.user check_profile_expiration():560| Expiration for config profile test-profile is no longer valid: 2023-12-11 23:17:10+00:00
...
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
