### PR TITLE
Feature/inquirer

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ flake8>=5.0.0
 flake8-black
 flake8-docstrings
 flake8-import-order
-moto
+moto<5.0.0
 pep8-naming
 pexpect
 pydocstyle

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setup(
     license=about["__license__"],
     zip_safe=False,
     install_requires=[required],
+    extras_require={
+        'inquirer': ['inquirer'],
+    },
     entry_points={
         "console_scripts": ["tokendito=tokendito.__main__:main"],
     },

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -571,6 +571,21 @@ def test_select_preferred_mfa_index(mocker, sample_json_response):
         mocker.patch("tokendito.user.collect_integer", return_value=output)
         assert select_preferred_mfa_index(mfa_options) == output
 
+
+def test_select_preferred_mfa_index_inquirer(mocker, sample_json_response):
+    """Test whether the function returns index entered by user."""
+    from tokendito.user import select_preferred_mfa_index
+    from tokendito.user import INQUIRER_AVAILABLE
+
+    if not INQUIRER_AVAILABLE:
+        pytest.skip("No items found")
+    else:
+        primary_auth = sample_json_response
+        mfa_options = primary_auth["okta_response_mfa"]["_embedded"]["factors"]
+        for output in mfa_options:
+            mocker.patch("tokendito.user.inquirer.prompt", return_value={"mfa_selection": output})
+            assert select_preferred_mfa_index(mfa_options) == output
+
 @pytest.mark.parametrize(
     "email",
     [

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -560,6 +560,9 @@ def test_mfa_option_info(factor_type, output):
 
 def test_select_preferred_mfa_index(mocker, sample_json_response):
     """Test whether the function returns index entered by user."""
+    # Don't enable inquirer for these tests
+    mocker.patch('tokendito.user.INQUIRER_AVAILABLE', False)
+
     from tokendito.user import select_preferred_mfa_index
 
     primary_auth = sample_json_response
@@ -567,7 +570,6 @@ def test_select_preferred_mfa_index(mocker, sample_json_response):
     for output in mfa_options:
         mocker.patch("tokendito.user.collect_integer", return_value=output)
         assert select_preferred_mfa_index(mfa_options) == output
-
 
 @pytest.mark.parametrize(
     "email",
@@ -577,6 +579,9 @@ def test_select_preferred_mfa_index(mocker, sample_json_response):
 )
 def test_select_preferred_mfa_index_output(email, capsys, mocker, sample_json_response):
     """Test whether the function gives correct output."""
+
+    # Don't enable inquirer for these tests
+    mocker.patch('tokendito.user.INQUIRER_AVAILABLE', False)
     from tokendito.config import config
     from tokendito.user import select_preferred_mfa_index
 

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -540,7 +540,8 @@ def prompt_role_choices(aut_tiles):
                           ),
         ]
         answers = inquirer.prompt(questions)
-        return answers['role_selection']
+        logger.debug(f"Selected role [{answers.get('role_selection')}]")
+        return answers.get('role_selection')
 
     # print("\nSelect your preferred MFA method and press Enter:")
     # for text, i in mfa_list:

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -456,6 +456,7 @@ def select_preferred_mfa_index(mfa_options, factor_key="provider", subfactor_key
     logger.debug("Show all the MFA options to the users.")
     logger.debug(json.dumps(mfa_options))
 
+
     longest_index = len(str(len(mfa_options)))
     longest_factor_name = max([len(d[factor_key]) for d in mfa_options])
     longest_subfactor_name = max([len(d[subfactor_key]) for d in mfa_options])
@@ -541,7 +542,7 @@ def prompt_role_choices(aut_tiles):
         ]
         answers = inquirer.prompt(questions)
         logger.debug(f"Selected role [{answers.get('role_selection')}]")
-        return answers.get('role_selection')
+        return answers['role_selection']
 
     # print("\nSelect your preferred MFA method and press Enter:")
     # for text, i in mfa_list:

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -544,13 +544,6 @@ def prompt_role_choices(aut_tiles):
         logger.debug(f"Selected role [{answers.get('role_selection')}]")
         return answers['role_selection']
 
-    # print("\nSelect your preferred MFA method and press Enter:")
-    # for text, i in mfa_list:
-    #     print(text)
-    #
-    # user_input = collect_integer(len(mfa_options))
-    #
-    # return user_input
     print("\nPlease select one of the following:")
     for role_item, i in role_list:
         print(role_item)

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -34,6 +34,14 @@ try:
 except ModuleNotFoundError:
     pass
 
+INQUIRER_AVAILABLE = False
+try:
+    import inquirer
+
+    INQUIRER_AVAILABLE = True
+except ModuleNotFoundError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 mask_items = []
@@ -447,25 +455,40 @@ def select_preferred_mfa_index(mfa_options, factor_key="provider", subfactor_key
     """
     logger.debug("Show all the MFA options to the users.")
     logger.debug(json.dumps(mfa_options))
-    print("\nSelect your preferred MFA method and press Enter:")
 
     longest_index = len(str(len(mfa_options)))
     longest_factor_name = max([len(d[factor_key]) for d in mfa_options])
     longest_subfactor_name = max([len(d[subfactor_key]) for d in mfa_options])
     factor_info_indent = max([len(mfa_option_info(d)) for d in mfa_options])
 
+    mfa_list = []
     for i, mfa_option in enumerate(mfa_options):
         factor_id = mfa_option.get("id", "Not presented")
         factor_info = mfa_option_info(mfa_option)
         mfa = mfa_option.get(subfactor_key, "Not presented")
         provider = mfa_option.get(factor_key, "Not presented")
-        print(
+        mfa_item = (
             f"[{i: >{longest_index}}]  "
             f"{provider: <{longest_factor_name}}  "
             f"{mfa: <{longest_subfactor_name}} "
             f"{factor_info: <{factor_info_indent}} "
             f"Id: {factor_id}"
         )
+        mfa_list.append((mfa_item, i))
+
+    if INQUIRER_AVAILABLE:
+        questions = [
+            inquirer.List('mfa_selection',
+                          message="Select your preferred MFA method and press Enter:",
+                          choices=mfa_list,
+                          ),
+        ]
+        answers = inquirer.prompt(questions)
+        return answers['mfa_selection']
+
+    print("\nSelect your preferred MFA method and press Enter:")
+    for text, i in mfa_list:
+        print(text)
 
     user_input = collect_integer(len(mfa_options))
 
@@ -492,13 +515,13 @@ def prompt_role_choices(aut_tiles):
                 aliases_mapping.append((tile["label"], role.split(":")[4], role, url))
 
     logger.debug("Ask user to select role")
-    print("\nPlease select one of the following:")
 
     longest_alias = max(len(i[1]) for i in aliases_mapping)
     longest_index = len(str(len(aliases_mapping)))
     aliases_mapping = sorted(aliases_mapping)
     print_label = ""
 
+    role_list = []
     for i, data in enumerate(aliases_mapping):
         label, alias, role, _ = data
         padding_index = longest_index - len(str(i))
@@ -506,8 +529,29 @@ def prompt_role_choices(aut_tiles):
             print_label = label
             print(f"\n{label}:")
 
-        print(f"[{i}] {padding_index * ' '}" f"{alias: <{longest_alias}}  {role}")
+        role_item = f"[{i}] {padding_index * ' '}" f"{alias: <{longest_alias}}  {role}"
+        role_list.append((role_item, (aliases_mapping[i][2], aliases_mapping[i][3])))
 
+    if INQUIRER_AVAILABLE:
+        questions = [
+            inquirer.List('role_selection',
+                          message="Please select one of the following:",
+                          choices=role_list,
+                          ),
+        ]
+        answers = inquirer.prompt(questions)
+        return answers['role_selection']
+
+    # print("\nSelect your preferred MFA method and press Enter:")
+    # for text, i in mfa_list:
+    #     print(text)
+    #
+    # user_input = collect_integer(len(mfa_options))
+    #
+    # return user_input
+    print("\nPlease select one of the following:")
+    for role_item, i in role_list:
+        print(role_item)
     user_input = collect_integer(len(aliases_mapping))
     selected_role = (aliases_mapping[user_input][2], aliases_mapping[user_input][3])
     logger.debug(f"Selected role [{user_input}]")


### PR DESCRIPTION
## Description
Add the ability to choose the mfa type and the role through interactive shell instead of index.

This has been added as an optional dependency with fallback if the inquirer lib is not present. Only because I don't understand the policies of the package maintainer here, with respect to the increase to the dependency tree. Not a huge bump for inquirer, but I also had another thought around textual so that we might be able to implement role search capabilities through smart filtering.

Validate with extras_requires -> pip install -e .[inquirer]

## Related Issue
N/A

## Motivation and Context
We have a list of over 40 roles, which gets hard to navigate and/or search for.

## How Has This Been Tested?
Validated with both inquirer installed and not installed.
Pytest run on 3.11.1

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X ] I have added tests that prove my fix is effective or that my feature works
- [ X ] New and existing unit tests pass locally with my changes
