### PR TITLE
feat: Use single MFA session to login to multiple profiles

### DIFF
--- a/tokendito/config.py
+++ b/tokendito/config.py
@@ -30,6 +30,7 @@ class Config(object):
             loglevel="INFO",
             log_output_file="",
             use_device_token=False,
+            use_session_token=False,
             mask_items=[],
             quiet=False,
         ),
@@ -50,6 +51,9 @@ class Config(object):
             tile=None,
             org=None,
             device_token=None,
+            session_token=None,
+            session_token_expiry=None,
+            session_id=None,
         ),
     )
 


### PR DESCRIPTION
## Description
Introducting a feature to use single MFA auth session to allow logging in to multiple profiles. The session `token` and `id` it stores, is only valid for 5 minutes, so there is low chance of the token being used by a bad actor.

To enable this functionality, set `user_use_session_token = true` in your [default] config.
When running for the first time, it would prompt MFA, but all subsequent calls to tokendito should result in successful authentication as long as the session is not expired.

Creating this PR to begin the discussion on the possibility of getting this feature to work for all usecases

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Having to perform MFA verification for multiple calls every morning is quite annoying. I want the ability to connect to multiple profiles that might share the same MFA. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- This has only been tested with Okta verify authenticator.
- This has only been tested to work when default profile is present and called [default]

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
