### PR TITLE
feat: add --configure list option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Version 2.5.0 of Tokendito introduces the following changes:
 
 - Support for multiple AWS profiles in a single configuration file.
 - Cross-platform input timeout feature with configurable login timeout (default: disabled).
+- Configuration listing with `--configure list` to display current settings and their sources.
 - System-wide installation instructions for multi-user environments.
 - Monthly Docker image rebuild to keep base layers current (fixes #164).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
   - [Default usage](#default-usage)
   - [Multi-tile-Guide](#multi-tile-guide)
   - [Single-command usage](#single-command-usage)
+  - [Listing current configuration](#listing-current-configuration)
   - [Additional command line reference](#additional-command-line-reference)
 - [Environment variables and user configuration](#environment-variables-and-user-configuration)
   - [Precedence](#precedence)
@@ -71,6 +72,40 @@ And execute:
 tokendito --profile engineer
 ```
 
+### Listing current configuration
+
+To view your current configuration values and where they are set from, use:
+
+``` txt
+tokendito --configure list
+```
+
+This displays a table showing each setting's name, current value, source type (default, ini-file, or env-var), and location:
+
+``` txt
+                        Name    Value                             Source          Location
+                        ----    -----                             ------          --------
+  [user]
+                  config_dir    /Users/you/.config/tokendito      default
+                 config_file    /Users/you/.config/tokendito...   default
+              config_profile    default                           default
+               login_timeout    0                                 default
+                    loglevel    INFO                              default
+  [aws]
+                     profile    <not set>                         default
+                      region    us-east-1                         default
+  [okta]
+                    username    jane.doe@acme.com                 ini-file        /Users/you/.config/tokendito/tokendito.ini
+                    password    ****                              ini-file        /Users/you/.config/tokendito/tokendito.ini
+                         org    https://acme.okta.com             env-var         TOKENDITO_OKTA_ORG
+```
+
+You can combine it with `--profile` to inspect a specific profile:
+
+``` txt
+tokendito --profile engineer --configure list
+```
+
 ### Additional command line reference
 
 ``` txt
@@ -85,7 +120,8 @@ Gets an STS token to use with the AWS CLI and SDK.
 options:
   -h, --help            show this help message and exit.
   --version             Displays version and exit.
-  --configure           Prompt user for configuration parameters.
+  --configure [list]    Prompt user for configuration parameters.
+                        Use '--configure list' to display current settings and their sources.
   --username OKTA_USERNAME
                         username to log in to Okta. You can also use the TOKENDITO_OKTA_USERNAME environment variable.
   --password OKTA_PASSWORD

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -1350,6 +1350,39 @@ def test_get_value_source_env_overrides_ini():
     assert location == "TOKENDITO_OKTA_USERNAME"
 
 
+def test_resolve_profile_cli_over_env(monkeypatch):
+    """Test that CLI --profile takes precedence over env var."""
+    import argparse
+
+    from tokendito.user import _resolve_profile
+
+    monkeypatch.setenv("TOKENDITO_USER_CONFIG_PROFILE", "env-profile")
+    args = argparse.Namespace(user_config_profile="cli-profile")
+    assert _resolve_profile(args) == "cli-profile"
+
+
+def test_resolve_profile_env_over_default(monkeypatch):
+    """Test that env var overrides the default profile."""
+    import argparse
+
+    from tokendito.user import _resolve_profile
+
+    monkeypatch.setenv("TOKENDITO_USER_CONFIG_PROFILE", "env-profile")
+    args = argparse.Namespace(user_config_profile="default")
+    assert _resolve_profile(args) == "env-profile"
+
+
+def test_resolve_profile_default(monkeypatch):
+    """Test that default profile is returned when no overrides."""
+    import argparse
+
+    from tokendito.user import _resolve_profile
+
+    monkeypatch.delenv("TOKENDITO_USER_CONFIG_PROFILE", raising=False)
+    args = argparse.Namespace(user_config_profile="default")
+    assert _resolve_profile(args) == "default"
+
+
 def test_format_value_masks_password():
     """Test that sensitive keys are masked."""
     from tokendito.user import _format_value

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -1269,3 +1269,246 @@ def test_multiple_profiles(mocker):
     assert patched.call_args_list[0].args[1] is False
     assert patched.call_args_list[1].args[1] is True
     assert patched.call_args_list[2].args[1] is True
+
+
+def test_configure_list_arg_parsing():
+    """Test that --configure list is parsed correctly."""
+    from tokendito import user
+
+    # No --configure
+    args = user.parse_cli_args([])
+    assert args.configure is False
+
+    # --configure (no subcommand, backward compat)
+    args = user.parse_cli_args(["--configure"])
+    assert args.configure is True
+
+    # --configure list
+    args = user.parse_cli_args(["--configure", "list"])
+    assert args.configure == "list"
+
+
+def test_configure_list_invalid_option(mocker):
+    """Test that --configure with invalid option exits with error."""
+    from tokendito import user
+
+    mocker.patch("tokendito.user.logger")
+    args = user.parse_cli_args(["--configure", "invalid"])
+    with pytest.raises(SystemExit) as exc_info:
+        user._handle_configure_subcommand(args)
+    assert exc_info.value.code == 1
+
+
+def test_get_value_source_env_var():
+    """Test _get_value_source returns env-var when set in environment config."""
+    from tokendito.config import Config
+    from tokendito.user import _get_value_source
+
+    config_env = Config(okta={"username": "testuser"})
+    source, location = _get_value_source(
+        "okta", "username", None, config_env, "/path/to/ini"
+    )
+    assert source == "env-var"
+    assert location == "TOKENDITO_OKTA_USERNAME"
+
+
+def test_get_value_source_ini_file():
+    """Test _get_value_source returns ini-file when set in INI config."""
+    from tokendito.config import Config
+    from tokendito.user import _get_value_source
+
+    config_ini = Config(okta={"org": "https://acme.okta.com"})
+    source, location = _get_value_source(
+        "okta", "org", config_ini, None, "/path/to/tokendito.ini"
+    )
+    assert source == "ini-file"
+    assert location == "/path/to/tokendito.ini"
+
+
+def test_get_value_source_default():
+    """Test _get_value_source returns default when not set anywhere."""
+    from tokendito.user import _get_value_source
+
+    source, location = _get_value_source(
+        "aws", "region", None, None, "/path/to/ini"
+    )
+    assert source == "default"
+    assert location == ""
+
+
+def test_get_value_source_env_overrides_ini():
+    """Test that env-var takes priority over ini-file."""
+    from tokendito.config import Config
+    from tokendito.user import _get_value_source
+
+    config_ini = Config(okta={"username": "ini-user"})
+    config_env = Config(okta={"username": "env-user"})
+    source, location = _get_value_source(
+        "okta", "username", config_ini, config_env, "/path/to/ini"
+    )
+    assert source == "env-var"
+    assert location == "TOKENDITO_OKTA_USERNAME"
+
+
+def test_format_value_masks_password():
+    """Test that sensitive keys are masked."""
+    from tokendito.user import _format_value
+
+    assert _format_value("password", "secret123", {"password"}) == "****"
+    assert _format_value("device_token", "tok123", {"device_token"}) == "****"
+
+
+def test_format_value_not_set():
+    """Test display of empty/None values."""
+    from tokendito.user import _format_value
+
+    assert _format_value("username", "", set()) == "<not set>"
+    assert _format_value("tile", None, set()) == "<not set>"
+    assert _format_value("mask_items", [], set()) == "<not set>"
+
+
+def test_format_value_boolean():
+    """Test boolean display."""
+    from tokendito.user import _format_value
+
+    assert _format_value("quiet", False, set()) == "false"
+    assert _format_value("use_device_token", True, set()) == "true"
+
+
+def test_format_value_normal():
+    """Test normal value display."""
+    from tokendito.user import _format_value
+
+    assert _format_value("region", "us-east-1", set()) == "us-east-1"
+    assert _format_value("login_timeout", 0, set()) == "0"
+
+
+def test_configure_list_output(capsys, mocker, tmpdir):
+    """Test configure_list produces formatted table output."""
+    import argparse
+
+    from tokendito import user
+
+    mocker.patch(
+        "tokendito.user._safe_load_ini", return_value=None
+    )
+    mocker.patch(
+        "tokendito.user.process_environment", return_value=None
+    )
+
+    args = argparse.Namespace(
+        user_config_file=str(tmpdir.join("tokendito.ini")),
+        user_config_profile="default",
+    )
+
+    user.configure_list(args)
+
+    captured = capsys.readouterr()
+    assert "Name" in captured.out
+    assert "Value" in captured.out
+    assert "Source" in captured.out
+    assert "Location" in captured.out
+    assert "[user]" in captured.out
+    assert "[aws]" in captured.out
+    assert "[okta]" in captured.out
+    assert "default" in captured.out
+
+
+def test_configure_list_with_ini(capsys, mocker, tmpdir):
+    """Test configure_list shows ini-file source for INI values."""
+    import argparse
+
+    from tokendito.config import Config
+    from tokendito import user
+
+    ini_path = str(tmpdir.join("tokendito.ini"))
+    ini_config = Config(okta={"org": "https://acme.okta.com"})
+    mocker.patch(
+        "tokendito.user._safe_load_ini", return_value=ini_config
+    )
+    mocker.patch(
+        "tokendito.user.process_environment", return_value=None
+    )
+
+    args = argparse.Namespace(
+        user_config_file=ini_path,
+        user_config_profile="default",
+    )
+
+    user.configure_list(args)
+
+    captured = capsys.readouterr()
+    assert "ini-file" in captured.out
+    assert ini_path in captured.out
+    assert "https://acme.okta.com" in captured.out
+
+
+def test_configure_list_with_env(capsys, mocker, tmpdir):
+    """Test configure_list shows env-var source for env values."""
+    import argparse
+
+    from tokendito.config import Config
+    from tokendito import user
+
+    env_config = Config(
+        okta={"username": "envuser@example.com"}
+    )
+    mocker.patch(
+        "tokendito.user._safe_load_ini", return_value=None
+    )
+    mocker.patch(
+        "tokendito.user.process_environment", return_value=env_config
+    )
+
+    args = argparse.Namespace(
+        user_config_file=str(tmpdir.join("tokendito.ini")),
+        user_config_profile="default",
+    )
+
+    user.configure_list(args)
+
+    captured = capsys.readouterr()
+    assert "env-var" in captured.out
+    assert "TOKENDITO_OKTA_USERNAME" in captured.out
+    assert "envuser@example.com" in captured.out
+
+
+def test_configure_list_masks_password(capsys, mocker, tmpdir):
+    """Test configure_list masks sensitive values."""
+    import argparse
+
+    from tokendito.config import Config
+    from tokendito import user
+
+    env_config = Config(okta={"password": "supersecret"})
+    mocker.patch(
+        "tokendito.user._safe_load_ini", return_value=None
+    )
+    mocker.patch(
+        "tokendito.user.process_environment", return_value=env_config
+    )
+
+    args = argparse.Namespace(
+        user_config_file=str(tmpdir.join("tokendito.ini")),
+        user_config_profile="default",
+    )
+
+    user.configure_list(args)
+
+    captured = capsys.readouterr()
+    assert "supersecret" not in captured.out
+    assert "****" in captured.out
+
+
+def test_configure_list_process_options_dispatch(mocker):
+    """Test that process_options dispatches to configure_list."""
+    from tokendito import user
+
+    mock_list = mocker.patch("tokendito.user.configure_list")
+    args = user.parse_cli_args(["--configure", "list"])
+
+    with pytest.raises(SystemExit):
+        user._handle_configure_subcommand(args)
+
+    # configure_list was called before sys.exit
+    mock_list.assert_called_once_with(args)

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -1376,9 +1376,14 @@ def _safe_load_ini(file, profile):
 def _resolve_profile(args):
     """Resolve the active profile from CLI args or environment.
 
+    CLI args take precedence over env vars per documented precedence.
+
     :param args: argparse namespace.
     :returns: profile name string.
     """
+    default_profile = config.get_defaults()["user"]["config_profile"]
+    if args.user_config_profile != default_profile:
+        return args.user_config_profile
     env_profile = os.environ.get("TOKENDITO_USER_CONFIG_PROFILE")
     if env_profile:
         return env_profile

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -186,8 +186,11 @@ def parse_cli_args(args):
     parser.add_argument("--version", action="store_true", help="Displays version and exit")
     parser.add_argument(
         "--configure",
-        action="store_true",
-        help="Prompt user for configuration parameters",
+        nargs="?",
+        const=True,
+        default=False,
+        help="Prompt user for configuration parameters. "
+        "Use '--configure list' to display current settings and their sources.",
     )
     parser.add_argument(
         "--username",
@@ -1313,12 +1316,144 @@ def collect_integer(valid_range=0):
     return user_input
 
 
-def process_options(args):
-    """Collect all user-specific credentials and config params."""
-    if args.version:
-        display_version()
-        sys.exit(0)
+def _get_value_source(section, key, config_ini, config_env, ini_file):
+    """Determine the source of a configuration value.
 
+    Check in reverse priority order to find the highest-priority source
+    that set the value.
+
+    :param section: config section name (user, aws, okta).
+    :param key: config key name.
+    :param config_ini: Config object from INI file, or None.
+    :param config_env: Config object from environment, or None.
+    :param ini_file: path to the INI file.
+    :returns: tuple of (source_type, location).
+    """
+    if config_env and key in getattr(config_env, section, {}):
+        env_name = f"TOKENDITO_{section}_{key}".upper()
+        return ("env-var", env_name)
+
+    if config_ini and key in getattr(config_ini, section, {}):
+        return ("ini-file", ini_file)
+
+    return ("default", "")
+
+
+def _format_value(key, value, sensitive_keys):
+    """Format a configuration value for display.
+
+    :param key: config key name.
+    :param value: the config value.
+    :param sensitive_keys: set of key names to mask.
+    :returns: formatted display string.
+    """
+    if key in sensitive_keys and value:
+        return "****"
+    if value is None or value == "" or value == []:
+        return "<not set>"
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _safe_load_ini(file, profile):
+    """Load INI file without exiting if the profile is missing.
+
+    :param file: path to the INI file.
+    :param profile: profile section to read.
+    :returns: Config object or None if profile not found.
+    """
+    try:
+        ini = configparser.RawConfigParser()
+        ini.read(file)
+        if ini.has_section(profile):
+            return process_ini_file(file, profile)
+    except configparser.Error:
+        pass
+    return None
+
+
+def _resolve_profile(args):
+    """Resolve the active profile from CLI args or environment.
+
+    :param args: argparse namespace.
+    :returns: profile name string.
+    """
+    env_profile = os.environ.get("TOKENDITO_USER_CONFIG_PROFILE")
+    if env_profile:
+        return env_profile
+    return args.user_config_profile
+
+
+def configure_list(args):
+    """Display current configuration values and their sources."""
+    profile = _resolve_profile(args)
+
+    config_ini = _safe_load_ini(args.user_config_file, profile)
+    config_env = process_environment()
+
+    merged = Config()
+    if config_ini:
+        merged.update(config_ini)
+    if config_env:
+        merged.update(config_env)
+
+    sensitive_keys = {"password", "device_token"}
+    skip_keys = {"mask_items"}
+
+    builtins.print(
+        f"{'Name':>28s}    {'Value':30s}    {'Source':12s}    Location"
+    )
+    builtins.print(
+        f"{'----':>28s}    {'-----':30s}    {'------':12s}    --------"
+    )
+
+    for section in ["user", "aws", "okta"]:
+        builtins.print(f"  [{section}]")
+        section_data = getattr(merged, section)
+
+        for key in sorted(section_data.keys()):
+            if key in skip_keys:
+                continue
+            value = section_data[key]
+
+            source_type, location = _get_value_source(
+                section, key, config_ini, config_env,
+                args.user_config_file,
+            )
+
+            display_value = _format_value(key, value, sensitive_keys)
+
+            builtins.print(
+                f"{key:>28s}    {display_value:30s}    "
+                f"{source_type:12s}    {location}"
+            )
+
+        builtins.print()
+
+
+def _handle_configure_subcommand(args):
+    """Handle --configure subcommands like 'list'.
+
+    :param args: argparse namespace.
+    """
+    if args.configure != "list":
+        logger.error(
+            f"Unknown configure option: {args.configure}. "
+            "Use '--configure list' to display settings."
+        )
+        sys.exit(1)
+    configure_list(args)
+    sys.exit(0)
+
+
+def _load_config_sources(args):
+    """Load configuration from all sources and merge into config.
+
+    Priority order: ini file < environment < CLI args < interactive.
+
+    :param args: argparse namespace.
+    """
     # 1: read ini file (if it exists)
     if not args.configure:
         config_ini = process_ini_file(args.user_config_file, args.user_config_profile)
@@ -1339,6 +1474,18 @@ def process_options(args):
     config_int = process_interactive_input(config, args.configure)
     if config_int:
         config.update(config_int)
+
+
+def process_options(args):
+    """Collect all user-specific credentials and config params."""
+    if args.version:
+        display_version()
+        sys.exit(0)
+
+    if args.configure and args.configure is not True:
+        _handle_configure_subcommand(args)
+
+    _load_config_sources(args)
 
     sanitize_config_values(config)
     logger.debug(f"Final configuration is {config}")


### PR DESCRIPTION
## Description

Add `--configure list` option to display current configuration values and their sources (default, ini-file, or env-var), similar to `aws configure list`.

## Changes

- `--configure` now accepts an optional `list` subcommand
- New functions: `configure_list`, `_get_value_source`, `_format_value`, `_safe_load_ini`, `_resolve_profile`, `_handle_configure_subcommand`, `_load_config_sources`
- Sensitive values (password, device_token) are masked with `****`
- Gracefully handles missing INI profiles
- Respects `TOKENDITO_USER_CONFIG_PROFILE` env var
- 15 new unit tests
- Documentation updated in README.md and docs/README.md

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed - [x] I have performed - [x] I have performed - [x] I have performed - [x] I have performed - [x] I have performed - [x] I have performed - [x] I have performeisting unit tests pass locally with my changes