### PR TITLE
feat: Add automatic credential renewal with intelligent scheduling

### DIFF
--- a/docs/AUTO_RENEWAL.md
+++ b/docs/AUTO_RENEWAL.md
@@ -1,0 +1,344 @@
+# Auto-Renewal Feature
+
+## Overview
+
+The auto-renewal feature automatically refreshes your AWS credentials before they expire, eliminating the need to manually re-authenticate throughout your workday.
+
+## Quick Start
+
+### 1. Enable Auto-Renewal
+
+```bash
+tokendito --auto-renew-enable \
+    --auto-renew-profiles default \
+    --auto-renew-profiles dev \
+    --auto-renew-profiles prod
+```
+
+### 2. Check Status
+
+```bash
+tokendito --auto-renew-status
+```
+
+Output:
+```
+Tokendito Auto-Renewal Status
+============================================================
+Enabled: True
+Renewal threshold: 30 minutes
+Check interval: 10 minutes (fallback)
+Max sleep time: 60 minutes (config refresh)
+
+Monitored Profiles (3):
+  - default: expires in 11.5 hours (2026-03-20 20:00:00+00:00)
+  - dev: expires in 11.5 hours (2026-03-20 20:00:05+00:00)
+  - prod: expires in 11.5 hours (2026-03-20 20:00:10+00:00)
+```
+
+### 3. Disable Auto-Renewal
+
+```bash
+tokendito --auto-renew-disable
+```
+
+## How It Works
+
+1. **Background Service**: On macOS, a launchd service runs in the background monitoring your credentials
+2. **Smart Scheduling**: The daemon calculates when credentials expire and sleeps until renewal is needed (no constant polling)
+3. **Batch Renewal**: Multiple profiles expiring around the same time are renewed together with a single authentication
+4. **Automatic Recovery**: The service automatically restarts after system sleep/wake
+
+## Configuration
+
+Auto-renewal settings are stored in your tokendito configuration file (typically `~/.config/tokendito/tokendito.ini`):
+
+```ini
+[auto-renewal]
+enabled = true
+profiles = default, dev, prod
+renewal_threshold_minutes = 30
+check_interval_minutes = 10
+max_sleep_minutes = 60
+```
+
+### Configuration Options
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `enabled` | Enable/disable auto-renewal | `false` |
+| `profiles` | Comma-separated list of profiles to monitor | (empty) |
+| `renewal_threshold_minutes` | Renew credentials this many minutes before expiration | `30` |
+| `check_interval_minutes` | Fallback interval when expiration time is unknown | `10` |
+| `max_sleep_minutes` | Maximum time between config checks (ensures responsiveness) | `60` |
+
+### Manual Configuration
+
+You can edit the configuration file directly:
+
+```bash
+vi ~/.config/tokendito/tokendito.ini
+```
+
+After manual changes, restart the service:
+
+```bash
+tokendito --auto-renew-disable
+tokendito --auto-renew-enable --auto-renew-profiles <profiles>
+```
+
+## Passwordless Renewal with Device Tokens
+
+For unattended renewal without password prompts, enable device tokens:
+
+```bash
+tokendito --profile default --use-device-token
+```
+
+After the initial authentication, the device token is saved and future renewals don't require your password or MFA approval.
+
+## Command Reference
+
+### Enable Auto-Renewal
+
+```bash
+tokendito --auto-renew-enable \
+    --auto-renew-profiles <profile1> \
+    --auto-renew-profiles <profile2>
+```
+
+Enables auto-renewal for the specified profiles. Can specify `--auto-renew-profiles` multiple times.
+
+### Check Status
+
+```bash
+tokendito --auto-renew-status
+```
+
+Displays:
+- Whether auto-renewal is enabled
+- Monitored profiles and their expiration times
+- Daemon service status (macOS)
+- Configuration settings
+
+### Disable Auto-Renewal
+
+```bash
+tokendito --auto-renew-disable
+```
+
+Disables auto-renewal and stops the background service (macOS).
+
+### Manual Renewal Check
+
+```bash
+tokendito-renew-daemon --check-once
+```
+
+Runs a single renewal check and exits. Useful for testing or manual renewal.
+
+## Advanced Topics
+
+### Multiple Profiles with Different Lifetimes
+
+The daemon intelligently handles profiles with different expiration times:
+
+```
+profile_a expires in 12 hours → Renewed in 11.5 hours
+profile_b expires in 6 hours  → Renewed in 5.5 hours
+profile_c expires in 2 hours  → Renewed in 1.5 hours
+```
+
+The daemon wakes up when the earliest renewal is needed, handles it, then recalculates for the next renewal.
+
+### Efficient Batch Renewal
+
+When multiple profiles expire around the same time, they're renewed together with **a single authentication**:
+
+```bash
+# Instead of 6 separate authentications:
+tokendito --profile profile1  # Authenticate
+tokendito --profile profile2  # Authenticate again
+# ... (4 more times)
+
+# The daemon does this:
+tokendito --multi-profiles profile1 \
+          --multi-profiles profile2 \
+          --multi-profiles profile3 \
+          --multi-profiles profile4 \
+          --multi-profiles profile5 \
+          --multi-profiles profile6
+# Authenticate once!
+```
+
+### Config Responsiveness
+
+The `max_sleep_minutes` setting (default: 60) ensures config changes are picked up promptly:
+
+- If credentials don't expire for 12 hours, the daemon doesn't sleep for 12 hours
+- Instead, it wakes every 60 minutes to check for config changes
+- This means if you add a new profile, it's noticed within an hour
+
+### Viewing Logs (macOS)
+
+```bash
+# Standard output
+tail -f ~/Library/Logs/tokendito/renewal.log
+
+# Error output
+tail -f ~/Library/Logs/tokendito/renewal.error.log
+```
+
+### Service Management (macOS)
+
+```bash
+# Check if service is running
+launchctl list | grep tokendito
+
+# Manually load service
+launchctl load ~/Library/LaunchAgents/com.tokendito.renewal.plist
+
+# Manually unload service
+launchctl unload ~/Library/LaunchAgents/com.tokendito.renewal.plist
+```
+
+## Platform Support
+
+| Platform | Auto-renewal | Background Service | System Wake Support |
+|----------|--------------|-------------------|---------------------|
+| **macOS** | ✅ | ✅ (launchd) | ✅ |
+| **Linux** | ✅ | Manual* | Manual* |
+| **Windows** | ✅ | Manual* | Manual* |
+
+\* On Linux/Windows, run the daemon manually: `tokendito-renew-daemon` or set up with systemd/Task Scheduler
+
+## Troubleshooting
+
+### Service Not Running
+
+Check service status:
+```bash
+tokendito --auto-renew-status
+```
+
+Restart service:
+```bash
+tokendito --auto-renew-disable
+tokendito --auto-renew-enable --auto-renew-profiles <profiles>
+```
+
+### Credentials Still Expiring
+
+- Verify the profile name in config matches your tokendito profile
+- Check `renewal_threshold_minutes` isn't too low
+- Verify daemon has necessary credentials (password or device token)
+
+### "Password not set" Error
+
+Enable device tokens for passwordless renewal:
+```bash
+tokendito --profile <name> --use-device-token
+```
+
+Or store password in config (less secure):
+```ini
+[profile_name]
+okta_password = your_password
+```
+
+### Check Daemon Logs
+
+View recent daemon activity:
+```bash
+tail -20 ~/Library/Logs/tokendito/renewal.error.log
+```
+
+## Security Considerations
+
+1. **Device Tokens**: Preferred method for automated renewal - no password stored
+2. **Stored Passwords**: If using stored passwords, ensure proper file permissions
+3. **Expiration Tracking**: Expiration times stored in plaintext (similar to AWS CLI)
+4. **User-Level Service**: Daemon runs as your user, not system-wide
+
+## Examples
+
+### Example 1: Development Workflow
+
+Enable auto-renewal for your dev and staging environments:
+
+```bash
+tokendito --auto-renew-enable \
+    --auto-renew-profiles dev \
+    --auto-renew-profiles staging
+
+# Work all day without re-authenticating
+```
+
+### Example 2: Multi-Account Setup
+
+Monitor multiple AWS accounts:
+
+```ini
+# tokendito.ini
+[account-a]
+okta_tile = https://company.okta.com/home/amazon_aws/abc123/456
+aws_role_arn = arn:aws:iam::111111111111:role/engineer
+
+[account-b]
+okta_tile = https://company.okta.com/home/amazon_aws/def456/789
+aws_role_arn = arn:aws:iam::222222222222:role/engineer
+
+[account-c]
+okta_tile = https://company.okta.com/home/amazon_aws/ghi789/012
+aws_role_arn = arn:aws:iam::333333333333:role/engineer
+```
+
+```bash
+tokendito --auto-renew-enable \
+    --auto-renew-profiles account-a \
+    --auto-renew-profiles account-b \
+    --auto-renew-profiles account-c
+```
+
+### Example 3: Custom Thresholds
+
+Adjust renewal timing:
+
+```ini
+[auto-renewal]
+enabled = true
+profiles = default
+renewal_threshold_minutes = 60    # Renew 1 hour before expiration
+check_interval_minutes = 5        # Check every 5 minutes (fallback)
+max_sleep_minutes = 30            # Check config every 30 minutes
+```
+
+## Best Practices
+
+1. **Use Device Tokens**: Enable `--use-device-token` to avoid storing passwords
+2. **Monitor Selectively**: Only add profiles you actively use to avoid unnecessary renewals
+3. **Check Logs Periodically**: Verify renewals are succeeding
+4. **Test Configuration**: Run `tokendito-renew-daemon --check-once` after setup
+
+## FAQ
+
+**Q: Will this work if my computer is asleep?**
+A: On macOS, the launchd service restarts after wake and immediately checks/renews credentials.
+
+**Q: How many times will I need to authenticate per day?**
+A: Once at the beginning when enabling device tokens, then the daemon handles renewals automatically. If you have multiple profiles expiring simultaneously, they're renewed with a single authentication.
+
+**Q: What happens if renewal fails?**
+A: The daemon logs the error and continues monitoring. It will retry at the next check interval. Check logs at `~/Library/Logs/tokendito/renewal.error.log`.
+
+**Q: Can I use this in CI/CD pipelines?**
+A: Yes, but for CI/CD you may want to use scheduled tasks instead of the daemon for better control.
+
+**Q: Does this use `--multi-profiles` for efficiency?**
+A: Yes! When multiple profiles need renewal at the same time, they're all renewed together with a single authentication, not separately.
+
+## See Also
+
+- [Configuration File Format](tokendito.ini.md)
+- [Multi-Profile Usage](README.md#multi-profile-usage)
+- [Command Line Reference](README.md#additional-command-line-reference)

--- a/docs/AUTO_RENEWAL.md
+++ b/docs/AUTO_RENEWAL.md
@@ -212,16 +212,56 @@ launchctl unload ~/Library/LaunchAgents/com.tokendito.renewal.plist
 
 \* On Linux/Windows, run the daemon manually: `tokendito-renew-daemon` or set up with systemd/Task Scheduler
 
+### macOS Login Items Note
+
+After enabling auto-renewal, you'll see an entry in **System Settings > Login Items & Extensions > App Background Activity**:
+
+- **Name**: "tokendito-renew-daemon"
+- **Developer**: "unidentified developer"
+
+This is expected behavior:
+
+- The daemon runs via Python, which isn't code-signed specifically for your organization
+- The "unidentified developer" message is normal for pip-installed tools
+- This does NOT indicate a security issue - it's your local Python environment
+- The service runs with your user permissions (not system-wide)
+
 ## Troubleshooting
+
+### Permission Denied When Enabling (macOS)
+
+**Error:** `[Errno 13] Permission denied: '/Users/username/Library/LaunchAgents/com.tokendito.renewal.plist'`
+
+**Cause:** Your `~/Library/LaunchAgents/` directory is owned by root instead of your user. This can happen when certain applications are installed.
+
+**Fix:**
+
+```bash
+# Check current ownership
+ls -la ~/Library/LaunchAgents/
+
+# If owned by root, fix it
+sudo chown $(whoami):staff ~/Library/LaunchAgents/
+
+# Verify ownership changed
+ls -la ~/Library/LaunchAgents/
+
+# Retry enabling auto-renewal
+tokendito --auto-renew-enable --auto-renew-profiles <profiles>
+```
+
+**Note:** This is a one-time fix. The `chown` command changes the directory ownership to your user account, allowing tokendito to create the launchd plist file.
 
 ### Service Not Running
 
 Check service status:
+
 ```bash
 tokendito --auto-renew-status
 ```
 
 Restart service:
+
 ```bash
 tokendito --auto-renew-disable
 tokendito --auto-renew-enable --auto-renew-profiles <profiles>
@@ -236,11 +276,13 @@ tokendito --auto-renew-enable --auto-renew-profiles <profiles>
 ### "Password not set" Error
 
 Enable device tokens for passwordless renewal:
+
 ```bash
 tokendito --profile <name> --use-device-token
 ```
 
 Or store password in config (less secure):
+
 ```ini
 [profile_name]
 okta_password = your_password
@@ -249,6 +291,7 @@ okta_password = your_password
 ### Check Daemon Logs
 
 View recent daemon activity:
+
 ```bash
 tail -20 ~/Library/Logs/tokendito/renewal.error.log
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
   - [Multi-tile-Guide](#multi-tile-guide)
   - [Single-command usage](#single-command-usage)
   - [Multi-profile usage](#multi-profile-usage)
+  - [Automatic credential renewal](#automatic-credential-renewal)
   - [Listing current configuration](#listing-current-configuration)
   - [Additional command line reference](#additional-command-line-reference)
 - [Environment variables and user configuration](#environment-variables-and-user-configuration)
@@ -132,6 +133,70 @@ aws --profile prod ec2 describe-instances
 - **Overrides `--aws-profile`**: The `--aws-profile` flag and the `TOKENDITO_AWS_PROFILE` environment variable are ignored. Instead, the tokendito INI profile name (e.g. `dev`, `staging`) is always used as the AWS profile name in `~/.aws/credentials`.
 - **Authentication is shared**: Okta authentication happens only once. Subsequent profiles reuse the session, so you will only see a single MFA prompt.
 - **Configuration inheritance**: Each profile inherits values from the `[default]` section of the INI file, so common settings only need to be specified once.
+
+### Automatic credential renewal
+
+Tokendito can automatically renew your AWS credentials before they expire, eliminating the need to manually re-authenticate throughout your workday.
+
+#### Quick start
+
+Enable auto-renewal for your profiles:
+
+``` txt
+tokendito --auto-renew-enable \
+    --auto-renew-profiles default \
+    --auto-renew-profiles dev \
+    --auto-renew-profiles prod
+```
+
+Check the status:
+
+``` txt
+tokendito --auto-renew-status
+```
+
+Disable auto-renewal:
+
+``` txt
+tokendito --auto-renew-disable
+```
+
+#### How it works
+
+1. **Background service**: On macOS, a launchd service monitors your credentials in the background
+2. **Smart scheduling**: The daemon calculates when credentials expire and sleeps until renewal is needed (no constant polling)
+3. **Batch renewal**: Multiple profiles expiring around the same time are renewed together with a single Okta authentication
+4. **Automatic recovery**: The service automatically restarts after system sleep/wake
+
+#### Configuration
+
+Settings are stored in your `tokendito.ini` file:
+
+``` ini
+[auto-renewal]
+enabled = true
+profiles = default, dev, prod
+renewal_threshold_minutes = 30    # Renew 30 minutes before expiration
+check_interval_minutes = 10       # Fallback check interval
+max_sleep_minutes = 60            # Check config at least every 60 minutes
+```
+
+#### Passwordless renewal with device tokens
+
+For unattended renewal without password prompts, enable device tokens during your initial authentication:
+
+``` txt
+tokendito --profile default --use-device-token
+```
+
+After the first authentication, the device token is saved and future renewals don't require your password or MFA approval.
+
+#### Platform support
+
+- **macOS**: Full support with automatic launchd service
+- **Linux/Windows**: Manual daemon execution required (or use systemd/Task Scheduler)
+
+For complete documentation, see [AUTO_RENEWAL.md](AUTO_RENEWAL.md).
 
 ### Listing current configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -181,16 +181,6 @@ check_interval_minutes = 10       # Fallback check interval
 max_sleep_minutes = 60            # Check config at least every 60 minutes
 ```
 
-#### Passwordless renewal with device tokens
-
-For unattended renewal without password prompts, enable device tokens during your initial authentication:
-
-``` txt
-tokendito --profile default --use-device-token
-```
-
-After the first authentication, the device token is saved and future renewals don't require your password or MFA approval.
-
 #### Platform support
 
 - **macOS**: Full support with automatic launchd service

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ setup(
     zip_safe=False,
     install_requires=[required],
     entry_points={
-        "console_scripts": ["tokendito=tokendito.__main__:main"],
+        "console_scripts": [
+            "tokendito=tokendito.__main__:main",
+            "tokendito-renew-daemon=tokendito.renewal:main",
+        ],
     },
 )

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,0 +1,340 @@
+# vim: set filetype=python ts=4 sw=4
+# -*- coding: utf-8 -*-
+"""Unit tests for the daemon module."""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchd only available on macOS")
+def test_get_launchd_plist_path():
+    """Test getting the launchd plist path."""
+    from tokendito.daemon import get_launchd_plist_path
+
+    result = get_launchd_plist_path()
+
+    assert isinstance(result, Path)
+    assert str(result).endswith("com.tokendito.renewal.plist")
+    assert "LaunchAgents" in str(result)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchd only available on macOS")
+def test_get_log_dir():
+    """Test getting the log directory path."""
+    from tokendito.daemon import get_log_dir
+
+    result = get_log_dir()
+
+    assert isinstance(result, Path)
+    assert "tokendito" in str(result)
+    assert "Logs" in str(result)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchd only available on macOS")
+def test_create_launchd_plist():
+    """Test creating launchd plist file."""
+    from tokendito.daemon import create_launchd_plist
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Mock the plist path to use temp directory
+        test_plist = Path(tmpdir) / "test.plist"
+
+        with patch("tokendito.daemon.get_launchd_plist_path") as mock_path:
+            with patch("tokendito.daemon.get_log_dir") as mock_log:
+                mock_path.return_value = test_plist
+                mock_log.return_value = Path(tmpdir) / "logs"
+
+                result = create_launchd_plist()
+
+                assert result is True
+                assert test_plist.exists()
+
+                # Verify plist content is valid
+                import plistlib
+
+                with open(test_plist, "rb") as f:
+                    plist_data = plistlib.load(f)
+
+                assert plist_data["Label"] == "com.tokendito.renewal"
+                assert "ProgramArguments" in plist_data
+                assert plist_data["RunAtLoad"] is True
+                assert plist_data["KeepAlive"] is True
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchd only available on macOS")
+@patch("tokendito.daemon.subprocess.run")
+def test_load_launchd_service_success(mock_run):
+    """Test successfully loading the launchd service."""
+    from tokendito.daemon import load_launchd_service
+
+    # Mock successful load
+    mock_result = Mock()
+    mock_result.returncode = 0
+    mock_run.return_value = mock_result
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_plist = Path(tmpdir) / "test.plist"
+        test_plist.touch()
+
+        with patch("tokendito.daemon.get_launchd_plist_path") as mock_path:
+            mock_path.return_value = test_plist
+
+            result = load_launchd_service()
+
+            assert result is True
+            # Should call launchctl unload then load
+            assert mock_run.call_count == 2
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchd only available on macOS")
+@patch("tokendito.daemon.subprocess.run")
+def test_load_launchd_service_failure(mock_run):
+    """Test failed loading of launchd service."""
+    from tokendito.daemon import load_launchd_service
+    import subprocess
+
+    # Mock failed load
+    mock_run.side_effect = subprocess.CalledProcessError(1, "launchctl", stderr="Error")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_plist = Path(tmpdir) / "test.plist"
+        test_plist.touch()
+
+        with patch("tokendito.daemon.get_launchd_plist_path") as mock_path:
+            mock_path.return_value = test_plist
+
+            result = load_launchd_service()
+
+            assert result is False
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchd only available on macOS")
+def test_load_launchd_service_no_plist():
+    """Test loading service when plist doesn't exist."""
+    from tokendito.daemon import load_launchd_service
+
+    with patch("tokendito.daemon.get_launchd_plist_path") as mock_path:
+        mock_path.return_value = Path("/nonexistent/file.plist")
+
+        result = load_launchd_service()
+
+        assert result is False
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchd only available on macOS")
+@patch("tokendito.daemon.subprocess.run")
+def test_unload_launchd_service_success(mock_run):
+    """Test successfully unloading the launchd service."""
+    from tokendito.daemon import unload_launchd_service
+
+    # Mock successful unload
+    mock_result = Mock()
+    mock_result.returncode = 0
+    mock_run.return_value = mock_result
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_plist = Path(tmpdir) / "test.plist"
+        test_plist.touch()
+
+        with patch("tokendito.daemon.get_launchd_plist_path") as mock_path:
+            mock_path.return_value = test_plist
+
+            result = unload_launchd_service()
+
+            assert result is True
+            mock_run.assert_called_once()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchd only available on macOS")
+@patch("tokendito.daemon.subprocess.run")
+def test_unload_launchd_service_not_loaded(mock_run):
+    """Test unloading service that is not loaded."""
+    from tokendito.daemon import unload_launchd_service
+    import subprocess
+
+    # Mock "not found" error (service not loaded)
+    mock_run.side_effect = subprocess.CalledProcessError(
+        1, "launchctl", stderr="Could not find specified service"
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_plist = Path(tmpdir) / "test.plist"
+        test_plist.touch()
+
+        with patch("tokendito.daemon.get_launchd_plist_path") as mock_path:
+            mock_path.return_value = test_plist
+
+            result = unload_launchd_service()
+
+            # Should return True (service wasn't loaded anyway)
+            assert result is True
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchd only available on macOS")
+@patch("tokendito.daemon.subprocess.run")
+def test_get_service_status(mock_run):
+    """Test getting service status."""
+    from tokendito.daemon import get_service_status
+
+    # Mock launchctl list output with the service
+    mock_result = Mock()
+    mock_result.returncode = 0
+    mock_result.stdout = "12345\t0\tcom.tokendito.renewal"
+    mock_run.return_value = mock_result
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_plist = Path(tmpdir) / "test.plist"
+        test_plist.touch()
+
+        with patch("tokendito.daemon.get_launchd_plist_path") as mock_path:
+            mock_path.return_value = test_plist
+
+            result = get_service_status()
+
+            assert result["platform_supported"] is True
+            assert result["plist_exists"] is True
+            assert result["loaded"] is True
+
+
+def test_get_service_status_non_macos():
+    """Test getting service status on non-macOS platform."""
+    from tokendito.daemon import get_service_status
+
+    with patch("sys.platform", "linux"):
+        result = get_service_status()
+
+        assert result["platform_supported"] is False
+        assert result["running"] is False
+
+
+@patch("tokendito.renewal.save_auto_renew_config")
+@patch("tokendito.renewal.get_auto_renew_config")
+@patch("tokendito.daemon.create_launchd_plist")
+@patch("tokendito.daemon.load_launchd_service")
+def test_enable_auto_renewal(mock_load, mock_create, mock_get, mock_save):
+    """Test enabling auto-renewal."""
+    from tokendito.daemon import enable_auto_renewal
+
+    # Configure mocks
+    mock_get.return_value = {
+        "enabled": False,
+        "profiles": [],
+        "renewal_threshold_minutes": 30,
+        "check_interval_minutes": 10,
+        "max_sleep_minutes": 60,
+    }
+    mock_save.return_value = True
+    mock_create.return_value = True
+    mock_load.return_value = True
+
+    with patch("sys.platform", "darwin"):
+        result = enable_auto_renewal(["profile1", "profile2"])
+
+        assert result is True
+        mock_save.assert_called_once()
+        mock_create.assert_called_once()
+        mock_load.assert_called_once()
+
+        # Verify profiles were added
+        saved_settings = mock_save.call_args[0][0]
+        assert "profile1" in saved_settings["profiles"]
+        assert "profile2" in saved_settings["profiles"]
+        assert saved_settings["enabled"] is True
+
+
+@patch("tokendito.renewal.save_auto_renew_config")
+@patch("tokendito.renewal.get_auto_renew_config")
+def test_enable_auto_renewal_save_failure(mock_get, mock_save):
+    """Test enabling auto-renewal when save fails."""
+    from tokendito.daemon import enable_auto_renewal
+
+    # Configure mocks
+    mock_get.return_value = {
+        "enabled": False,
+        "profiles": [],
+        "renewal_threshold_minutes": 30,
+        "check_interval_minutes": 10,
+        "max_sleep_minutes": 60,
+    }
+    mock_save.return_value = False
+
+    result = enable_auto_renewal(["profile1"])
+
+    assert result is False
+
+
+@patch("tokendito.renewal.save_auto_renew_config")
+@patch("tokendito.renewal.get_auto_renew_config")
+@patch("tokendito.daemon.unload_launchd_service")
+def test_disable_auto_renewal(mock_unload, mock_get, mock_save):
+    """Test disabling auto-renewal."""
+    from tokendito.daemon import disable_auto_renewal
+
+    # Configure mocks
+    mock_get.return_value = {
+        "enabled": True,
+        "profiles": ["profile1"],
+        "renewal_threshold_minutes": 30,
+        "check_interval_minutes": 10,
+        "max_sleep_minutes": 60,
+    }
+    mock_save.return_value = True
+    mock_unload.return_value = True
+
+    with patch("sys.platform", "darwin"):
+        result = disable_auto_renewal()
+
+        assert result is True
+        mock_save.assert_called_once()
+        mock_unload.assert_called_once()
+
+        # Verify enabled was set to False
+        saved_settings = mock_save.call_args[0][0]
+        assert saved_settings["enabled"] is False
+
+
+@patch("tokendito.renewal.get_auto_renew_config")
+@patch("tokendito.daemon.get_service_status")
+@patch("tokendito.renewal.get_credential_expiration")
+def test_display_status(mock_get_exp, mock_status, mock_config, capsys):
+    """Test displaying auto-renewal status."""
+    from tokendito.daemon import display_status
+    from datetime import datetime, timedelta, timezone
+
+    # Configure mocks
+    mock_config.return_value = {
+        "enabled": True,
+        "profiles": ["profile1", "profile2"],
+        "renewal_threshold_minutes": 30,
+        "check_interval_minutes": 10,
+        "max_sleep_minutes": 60,
+    }
+
+    mock_status.return_value = {
+        "platform_supported": True,
+        "plist_exists": True,
+        "loaded": True,
+        "running": True,
+    }
+
+    # Mock credential expiration
+    exp_time = datetime.now(timezone.utc) + timedelta(hours=2)
+    mock_get_exp.return_value = exp_time
+
+    with patch("sys.platform", "darwin"):
+        display_status()
+
+    # Capture output
+    captured = capsys.readouterr()
+
+    # Verify output contains expected information
+    assert "Auto-Renewal Status" in captured.out
+    assert "Enabled: True" in captured.out
+    assert "profile1" in captured.out
+    assert "profile2" in captured.out
+    assert "Daemon Service:" in captured.out

--- a/tests/unit/test_renewal.py
+++ b/tests/unit/test_renewal.py
@@ -1,0 +1,426 @@
+# vim: set filetype=python ts=4 sw=4
+# -*- coding: utf-8 -*-
+"""Unit tests for the renewal module."""
+
+import configparser
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+
+def test_parse_expiration_time():
+    """Test parsing various expiration time formats."""
+    from tokendito.renewal import parse_expiration_time
+
+    # Test ISO 8601 with timezone
+    result = parse_expiration_time("2026-03-20T08:00:46+00:00")
+    assert result is not None
+    assert isinstance(result, datetime)
+    assert result.year == 2026
+    assert result.month == 3
+    assert result.day == 20
+
+    # Test ISO 8601 with Z timezone
+    result = parse_expiration_time("2026-03-20T08:00:46Z")
+    assert result is not None
+
+    # Test invalid format
+    result = parse_expiration_time("invalid")
+    assert result is None
+
+    # Test None input
+    result = parse_expiration_time(None)
+    assert result is None
+
+
+def test_get_credential_expiration():
+    """Test reading credential expiration from AWS credentials file."""
+    from tokendito.renewal import get_credential_expiration
+
+    # Create temporary credentials file
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".ini") as f:
+        f.write("[default]\n")
+        f.write("aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n")
+        f.write("aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n")
+        f.write("aws_session_token = example_token\n")
+        f.write("x_security_token_expires = 2026-03-20T08:00:46+00:00\n")
+        creds_file = f.name
+
+    try:
+        # Test reading expiration
+        result = get_credential_expiration("default", creds_file)
+        assert result is not None
+        assert isinstance(result, datetime)
+
+        # Test non-existent profile
+        result = get_credential_expiration("nonexistent", creds_file)
+        assert result is None
+
+        # Test non-existent file
+        result = get_credential_expiration("default", "/nonexistent/file")
+        assert result is None
+
+    finally:
+        os.unlink(creds_file)
+
+
+def test_check_profile_needs_renewal():
+    """Test checking if a profile needs renewal."""
+    from tokendito.renewal import check_profile_needs_renewal
+
+    # Create temporary credentials file with credentials expiring in 1 hour
+    expiration = datetime.now(timezone.utc) + timedelta(hours=1)
+    expiration_str = expiration.isoformat()
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".ini") as f:
+        f.write("[test_profile]\n")
+        f.write("aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n")
+        f.write("x_security_token_expires = " + expiration_str + "\n")
+        creds_file = f.name
+
+    try:
+        # Test with 30-minute threshold (should not need renewal)
+        needs_renewal, time_left = check_profile_needs_renewal(
+            "test_profile", renewal_threshold_minutes=30, credentials_file=creds_file
+        )
+        assert needs_renewal is False
+        assert time_left is not None
+
+        # Test with 90-minute threshold (should need renewal)
+        needs_renewal, time_left = check_profile_needs_renewal(
+            "test_profile", renewal_threshold_minutes=90, credentials_file=creds_file
+        )
+        assert needs_renewal is True
+
+        # Test with non-existent profile (should need renewal)
+        needs_renewal, time_left = check_profile_needs_renewal(
+            "nonexistent", renewal_threshold_minutes=30, credentials_file=creds_file
+        )
+        assert needs_renewal is True
+        assert time_left is None
+
+    finally:
+        os.unlink(creds_file)
+
+
+@patch("subprocess.run")
+def test_renew_profiles_success(mock_run):
+    """Test successful renewal of multiple profiles."""
+    from tokendito.renewal import renew_profiles
+
+    # Mock successful subprocess run
+    mock_result = Mock()
+    mock_result.returncode = 0
+    mock_run.return_value = mock_result
+
+    # Test renewal of multiple profiles
+    profiles = ["profile1", "profile2", "profile3"]
+    result = renew_profiles(profiles)
+
+    assert result is True
+    mock_run.assert_called_once()
+
+    # Verify the command includes --multi-profiles for each profile
+    call_args = mock_run.call_args
+    cmd = call_args[0][0]
+    assert "tokendito" in cmd
+    assert "--multi-profiles" in cmd
+    assert cmd.count("--multi-profiles") == 3
+
+
+@patch("subprocess.run")
+def test_renew_profiles_failure(mock_run):
+    """Test failed renewal of profiles."""
+    from tokendito.renewal import renew_profiles
+
+    # Mock failed subprocess run
+    mock_result = Mock()
+    mock_result.returncode = 1
+    mock_result.stderr = "Authentication failed"
+    mock_run.return_value = mock_result
+
+    # Test renewal failure
+    profiles = ["profile1", "profile2"]
+    result = renew_profiles(profiles)
+
+    assert result is False
+
+
+@patch("subprocess.run")
+def test_renew_profiles_timeout(mock_run):
+    """Test renewal timeout."""
+    from tokendito.renewal import renew_profiles
+    import subprocess
+
+    # Mock timeout
+    mock_run.side_effect = subprocess.TimeoutExpired("tokendito", 600)
+
+    # Test renewal timeout
+    profiles = ["profile1"]
+    result = renew_profiles(profiles)
+
+    assert result is False
+
+
+def test_renew_profiles_empty_list():
+    """Test renewal with empty profile list."""
+    from tokendito.renewal import renew_profiles
+
+    # Test with empty list
+    result = renew_profiles([])
+    assert result is True
+
+
+def test_get_auto_renew_config():
+    """Test reading auto-renewal configuration."""
+    from tokendito.renewal import get_auto_renew_config
+
+    # Create temporary config file
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".ini") as f:
+        f.write("[auto-renewal]\n")
+        f.write("enabled = true\n")
+        f.write("profiles = profile1, profile2, profile3\n")
+        f.write("renewal_threshold_minutes = 45\n")
+        f.write("check_interval_minutes = 15\n")
+        f.write("max_sleep_minutes = 120\n")
+        config_file = f.name
+
+    try:
+        # Test reading config
+        settings = get_auto_renew_config(config_file)
+
+        assert settings["enabled"] is True
+        assert settings["profiles"] == ["profile1", "profile2", "profile3"]
+        assert settings["renewal_threshold_minutes"] == 45
+        assert settings["check_interval_minutes"] == 15
+        assert settings["max_sleep_minutes"] == 120
+
+    finally:
+        os.unlink(config_file)
+
+
+def test_get_auto_renew_config_defaults():
+    """Test default auto-renewal configuration."""
+    from tokendito.renewal import get_auto_renew_config
+
+    # Test with non-existent file (should return defaults)
+    settings = get_auto_renew_config("/nonexistent/file")
+
+    assert settings["enabled"] is False
+    assert settings["profiles"] == []
+    assert settings["renewal_threshold_minutes"] == 30
+    assert settings["check_interval_minutes"] == 10
+    assert settings["max_sleep_minutes"] == 60
+
+
+def test_save_auto_renew_config():
+    """Test saving auto-renewal configuration."""
+    from tokendito.renewal import get_auto_renew_config, save_auto_renew_config
+
+    # Create temporary config file
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_file = os.path.join(tmpdir, "test.ini")
+
+        # Test saving config
+        settings = {
+            "enabled": True,
+            "profiles": ["dev", "staging", "prod"],
+            "renewal_threshold_minutes": 60,
+            "check_interval_minutes": 5,
+            "max_sleep_minutes": 30,
+        }
+
+        result = save_auto_renew_config(settings, config_file)
+        assert result is True
+
+        # Verify saved config
+        loaded = get_auto_renew_config(config_file)
+        assert loaded["enabled"] == settings["enabled"]
+        assert loaded["profiles"] == settings["profiles"]
+        assert loaded["renewal_threshold_minutes"] == settings["renewal_threshold_minutes"]
+        assert loaded["check_interval_minutes"] == settings["check_interval_minutes"]
+        assert loaded["max_sleep_minutes"] == settings["max_sleep_minutes"]
+
+
+def test_calculate_next_check_time():
+    """Test calculating next check time based on credential expirations."""
+    from tokendito.renewal import calculate_next_check_time
+
+    # Create temporary credentials file with various expiration times
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".ini") as f:
+        now = datetime.now(timezone.utc)
+
+        # Profile expiring in 2 hours
+        exp1 = now + timedelta(hours=2)
+        f.write("[profile_2h]\n")
+        f.write(f"x_security_token_expires = {exp1.isoformat()}\n")
+
+        # Profile expiring in 6 hours
+        exp2 = now + timedelta(hours=6)
+        f.write("[profile_6h]\n")
+        f.write(f"x_security_token_expires = {exp2.isoformat()}\n")
+
+        creds_file = f.name
+
+    try:
+        with patch("tokendito.renewal.get_credential_expiration") as mock_get_exp:
+            # Mock returning expiration times
+            def get_exp_side_effect(profile_name, creds_file=None):
+                if profile_name == "profile_2h":
+                    return now + timedelta(hours=2)
+                elif profile_name == "profile_6h":
+                    return now + timedelta(hours=6)
+                return None
+
+            mock_get_exp.side_effect = get_exp_side_effect
+
+            # Test with 30-minute threshold
+            # Should wake up for profile_2h in 1.5 hours (90 minutes)
+            sleep_seconds = calculate_next_check_time(
+                ["profile_2h", "profile_6h"],
+                renewal_threshold_minutes=30,
+                check_interval_minutes=10,
+                max_sleep_minutes=60,
+            )
+
+            # Should be capped at 60 minutes
+            assert sleep_seconds == 60 * 60
+
+            # Test with no valid profiles (should use fallback)
+            sleep_seconds = calculate_next_check_time(
+                ["nonexistent"],
+                renewal_threshold_minutes=30,
+                check_interval_minutes=15,
+                max_sleep_minutes=60,
+            )
+
+            # Should use check_interval_minutes
+            assert sleep_seconds == 15 * 60
+
+    finally:
+        os.unlink(creds_file)
+
+
+@patch("tokendito.renewal.time.sleep")
+@patch("tokendito.renewal.get_auto_renew_config")
+@patch("tokendito.renewal.run_renewal_check")
+def test_run_renewal_daemon(mock_check, mock_config, mock_sleep):
+    """Test the renewal daemon main loop."""
+    from tokendito.renewal import run_renewal_daemon
+
+    # Configure mock to stop after one iteration
+    call_count = [0]
+
+    def config_side_effect(config_file=None):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return {
+                "enabled": True,
+                "profiles": ["profile1"],
+                "renewal_threshold_minutes": 30,
+                "check_interval_minutes": 10,
+                "max_sleep_minutes": 60,
+            }
+        else:
+            # Disable on second call to exit loop
+            return {
+                "enabled": False,
+                "profiles": [],
+                "renewal_threshold_minutes": 30,
+                "check_interval_minutes": 10,
+                "max_sleep_minutes": 60,
+            }
+
+    mock_config.side_effect = config_side_effect
+    mock_check.return_value = 0
+
+    # Run daemon (should exit after checking once)
+    run_renewal_daemon()
+
+    # Verify daemon checked for renewals
+    assert mock_check.called
+    assert mock_sleep.called
+
+
+@patch("tokendito.renewal.renew_profiles")
+@patch("tokendito.renewal.check_profile_needs_renewal")
+@patch("tokendito.renewal.get_auto_renew_config")
+def test_run_renewal_check(mock_config, mock_check_profile, mock_renew):
+    """Test running a single renewal check."""
+    from tokendito.renewal import run_renewal_check
+
+    # Configure mocks
+    mock_config.return_value = {
+        "enabled": True,
+        "profiles": ["profile1", "profile2", "profile3"],
+        "renewal_threshold_minutes": 30,
+        "check_interval_minutes": 10,
+        "max_sleep_minutes": 60,
+    }
+
+    # Make profile1 and profile3 need renewal
+    def check_side_effect(profile_name, threshold):
+        if profile_name in ["profile1", "profile3"]:
+            return (True, timedelta(minutes=20))
+        return (False, timedelta(hours=5))
+
+    mock_check_profile.side_effect = check_side_effect
+    mock_renew.return_value = True
+
+    # Run renewal check
+    result = run_renewal_check()
+
+    # Should have renewed 2 profiles
+    assert result == 2
+
+    # Verify renew_profiles called with correct profiles
+    mock_renew.assert_called_once()
+    call_args = mock_renew.call_args[0][0]
+    assert "profile1" in call_args
+    assert "profile3" in call_args
+    assert "profile2" not in call_args
+
+
+@patch("tokendito.renewal.get_auto_renew_config")
+def test_run_renewal_check_disabled(mock_config):
+    """Test renewal check when auto-renewal is disabled."""
+    from tokendito.renewal import run_renewal_check
+
+    # Configure mock with disabled auto-renewal
+    mock_config.return_value = {
+        "enabled": False,
+        "profiles": ["profile1"],
+        "renewal_threshold_minutes": 30,
+        "check_interval_minutes": 10,
+        "max_sleep_minutes": 60,
+    }
+
+    # Run renewal check
+    result = run_renewal_check()
+
+    # Should return 0 (nothing renewed)
+    assert result == 0
+
+
+@patch("tokendito.renewal.get_auto_renew_config")
+def test_run_renewal_check_no_profiles(mock_config):
+    """Test renewal check when no profiles are configured."""
+    from tokendito.renewal import run_renewal_check
+
+    # Configure mock with no profiles
+    mock_config.return_value = {
+        "enabled": True,
+        "profiles": [],
+        "renewal_threshold_minutes": 30,
+        "check_interval_minutes": 10,
+        "max_sleep_minutes": 60,
+    }
+
+    # Run renewal check
+    result = run_renewal_check()
+
+    # Should return 0 (nothing renewed)
+    assert result == 0

--- a/tokendito/daemon.py
+++ b/tokendito/daemon.py
@@ -49,12 +49,19 @@ def create_launchd_plist(config_file=None):
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    # Get Python executable and tokendito module path
-    python_exe = sys.executable
-    tokendito_cmd = ["tokendito-renew-daemon"]
+    # Find the tokendito-renew-daemon entry point
+    # Using shutil.which to locate it in PATH
+    import shutil  # noqa: C0415
+    daemon_cmd = shutil.which("tokendito-renew-daemon")
 
-    # Build command
-    program_args = [python_exe, "-m", "tokendito.renewal"]
+    if not daemon_cmd:
+        # Fallback to python -m if entry point not found
+        logger.warning("tokendito-renew-daemon not found in PATH, using python -m fallback")
+        daemon_cmd = sys.executable
+        program_args = [daemon_cmd, "-m", "tokendito.renewal"]
+    else:
+        # Use the entry point directly (shows better name in macOS)
+        program_args = [daemon_cmd]
     if config_file:
         program_args.extend(["--config-file", config_file])
 

--- a/tokendito/daemon.py
+++ b/tokendito/daemon.py
@@ -65,6 +65,9 @@ def create_launchd_plist(config_file=None):
     if config_file:
         program_args.extend(["--config-file", config_file])
 
+    # Get user's PATH to ensure tokendito command can be found
+    user_path = os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")
+
     # Create plist structure
     plist_data = {
         "Label": "com.tokendito.renewal",
@@ -74,6 +77,9 @@ def create_launchd_plist(config_file=None):
         "StandardOutPath": str(log_dir / "renewal.log"),
         "StandardErrorPath": str(log_dir / "renewal.error.log"),
         "StartInterval": 600,  # Run every 10 minutes as fallback
+        "EnvironmentVariables": {
+            "PATH": user_path,  # Include user's PATH so tokendito command can be found
+        },
     }
 
     try:

--- a/tokendito/daemon.py
+++ b/tokendito/daemon.py
@@ -1,0 +1,335 @@
+# vim: set filetype=python ts=4 sw=4
+# -*- coding: utf-8 -*-
+"""Daemon management for tokendito auto-renewal on macOS."""
+
+import logging
+import os
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def get_launchd_plist_path():
+    """Get the path to the launchd plist file.
+
+    :return: Path to plist file
+    """
+    home = Path.home()
+    launchd_dir = home / "Library" / "LaunchAgents"
+    return launchd_dir / "com.tokendito.renewal.plist"
+
+
+def get_log_dir():
+    """Get the directory for daemon logs.
+
+    :return: Path to log directory
+    """
+    home = Path.home()
+    log_dir = home / "Library" / "Logs" / "tokendito"
+    return log_dir
+
+
+def create_launchd_plist(config_file=None):
+    """Create launchd plist file for auto-renewal daemon.
+
+    :param config_file: Path to tokendito config file
+    :return: True if successful, False otherwise
+    """
+    if sys.platform != "darwin":
+        logger.error("Launchd is only available on macOS")
+        return False
+
+    plist_path = get_launchd_plist_path()
+    log_dir = get_log_dir()
+
+    # Ensure directories exist
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Get Python executable and tokendito module path
+    python_exe = sys.executable
+    tokendito_cmd = ["tokendito-renew-daemon"]
+
+    # Build command
+    program_args = [python_exe, "-m", "tokendito.renewal"]
+    if config_file:
+        program_args.extend(["--config-file", config_file])
+
+    # Create plist structure
+    plist_data = {
+        "Label": "com.tokendito.renewal",
+        "ProgramArguments": program_args,
+        "RunAtLoad": True,
+        "KeepAlive": True,
+        "StandardOutPath": str(log_dir / "renewal.log"),
+        "StandardErrorPath": str(log_dir / "renewal.error.log"),
+        "StartInterval": 600,  # Run every 10 minutes as fallback
+    }
+
+    try:
+        with open(plist_path, "wb") as f:
+            plistlib.dump(plist_data, f)
+
+        logger.info(f"Created launchd plist at {plist_path}")
+        return True
+
+    except (OSError, ValueError) as err:
+        logger.error(f"Error creating launchd plist: {err}")
+        return False
+
+
+def load_launchd_service():
+    """Load the tokendito renewal service with launchd.
+
+    :return: True if successful, False otherwise
+    """
+    if sys.platform != "darwin":
+        logger.error("Launchd is only available on macOS")
+        return False
+
+    plist_path = get_launchd_plist_path()
+
+    if not plist_path.exists():
+        logger.error(f"Plist file not found at {plist_path}")
+        return False
+
+    try:
+        # Unload first if already loaded (ignore errors)
+        subprocess.run(
+            ["launchctl", "unload", str(plist_path)],
+            capture_output=True,
+            check=False
+        )
+
+        # Load the service
+        result = subprocess.run(
+            ["launchctl", "load", str(plist_path)],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+        logger.info("Successfully loaded tokendito renewal service")
+        return True
+
+    except subprocess.CalledProcessError as err:
+        logger.error(f"Error loading launchd service: {err.stderr}")
+        return False
+    except Exception as err:
+        logger.error(f"Unexpected error loading service: {err}")
+        return False
+
+
+def unload_launchd_service():
+    """Unload the tokendito renewal service from launchd.
+
+    :return: True if successful, False otherwise
+    """
+    if sys.platform != "darwin":
+        logger.error("Launchd is only available on macOS")
+        return False
+
+    plist_path = get_launchd_plist_path()
+
+    if not plist_path.exists():
+        logger.debug(f"Plist file not found at {plist_path}, nothing to unload")
+        return True
+
+    try:
+        result = subprocess.run(
+            ["launchctl", "unload", str(plist_path)],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+        logger.info("Successfully unloaded tokendito renewal service")
+        return True
+
+    except subprocess.CalledProcessError as err:
+        # Service might not be loaded, which is fine
+        if "Could not find specified service" in err.stderr:
+            logger.debug("Service was not loaded")
+            return True
+        logger.error(f"Error unloading launchd service: {err.stderr}")
+        return False
+    except Exception as err:
+        logger.error(f"Unexpected error unloading service: {err}")
+        return False
+
+
+def get_service_status():
+    """Check if the tokendito renewal service is running.
+
+    :return: dict with status information
+    """
+    status = {
+        "running": False,
+        "loaded": False,
+        "plist_exists": False,
+        "platform_supported": sys.platform == "darwin",
+    }
+
+    if not status["platform_supported"]:
+        return status
+
+    plist_path = get_launchd_plist_path()
+    status["plist_exists"] = plist_path.exists()
+
+    if not status["plist_exists"]:
+        return status
+
+    try:
+        # Check if service is loaded
+        result = subprocess.run(
+            ["launchctl", "list"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+        if "com.tokendito.renewal" in result.stdout:
+            status["loaded"] = True
+
+            # Try to get more detailed status
+            detail_result = subprocess.run(
+                ["launchctl", "list", "com.tokendito.renewal"],
+                capture_output=True,
+                text=True,
+                check=False
+            )
+
+            if detail_result.returncode == 0:
+                # Parse output to check if it's running
+                # Output format: {"Label": "...", "PID": ..., "LastExitStatus": ...}
+                if '"PID"' in detail_result.stdout or 'PID =' in detail_result.stdout:
+                    status["running"] = True
+
+    except Exception as err:
+        logger.debug(f"Error checking service status: {err}")
+
+    return status
+
+
+def enable_auto_renewal(profiles, config_file=None):
+    """Enable auto-renewal for specified profiles.
+
+    :param profiles: List of profile names to monitor
+    :param config_file: Path to tokendito config file
+    :return: True if successful, False otherwise
+    """
+    from tokendito.renewal import get_auto_renew_config, save_auto_renew_config
+
+    # Get current settings
+    settings = get_auto_renew_config(config_file)
+
+    # Update settings
+    settings["enabled"] = True
+    settings["profiles"] = list(set(settings.get("profiles", []) + profiles))
+
+    # Save configuration
+    if not save_auto_renew_config(settings, config_file):
+        logger.error("Failed to save auto-renewal configuration")
+        return False
+
+    # On macOS, set up launchd service
+    if sys.platform == "darwin":
+        if not create_launchd_plist(config_file):
+            logger.error("Failed to create launchd plist")
+            return False
+
+        if not load_launchd_service():
+            logger.error("Failed to load launchd service")
+            return False
+
+        logger.info("Auto-renewal enabled and service started")
+    else:
+        logger.warning(
+            "Automatic daemon management is only supported on macOS. "
+            "You can manually run 'tokendito-renew-daemon' to start the renewal service."
+        )
+
+    return True
+
+
+def disable_auto_renewal(config_file=None):
+    """Disable auto-renewal.
+
+    :param config_file: Path to tokendito config file
+    :return: True if successful, False otherwise
+    """
+    from tokendito.renewal import get_auto_renew_config, save_auto_renew_config
+
+    # Get current settings
+    settings = get_auto_renew_config(config_file)
+
+    # Update settings
+    settings["enabled"] = False
+
+    # Save configuration
+    if not save_auto_renew_config(settings, config_file):
+        logger.error("Failed to save auto-renewal configuration")
+        return False
+
+    # On macOS, stop launchd service
+    if sys.platform == "darwin":
+        if not unload_launchd_service():
+            logger.error("Failed to unload launchd service")
+            return False
+
+        logger.info("Auto-renewal disabled and service stopped")
+    else:
+        logger.info("Auto-renewal disabled")
+
+    return True
+
+
+def display_status(config_file=None):
+    """Display auto-renewal status.
+
+    :param config_file: Path to tokendito config file
+    """
+    from tokendito.renewal import get_auto_renew_config, get_credential_expiration
+
+    settings = get_auto_renew_config(config_file)
+    service_status = get_service_status()
+
+    print("\nTokendito Auto-Renewal Status")
+    print("=" * 60)
+    print(f"Enabled: {settings['enabled']}")
+    print(f"Renewal threshold: {settings['renewal_threshold_minutes']} minutes")
+    print(f"Check interval: {settings['check_interval_minutes']} minutes (fallback)")
+    print(f"Max sleep time: {settings['max_sleep_minutes']} minutes (config refresh)")
+
+    if sys.platform == "darwin":
+        print(f"\nDaemon Service:")
+        print(f"  Plist exists: {service_status['plist_exists']}")
+        print(f"  Loaded: {service_status['loaded']}")
+        print(f"  Running: {service_status['running']}")
+
+        if service_status['plist_exists']:
+            plist_path = get_launchd_plist_path()
+            print(f"  Plist location: {plist_path}")
+
+        log_dir = get_log_dir()
+        print(f"  Log directory: {log_dir}")
+
+    print(f"\nMonitored Profiles ({len(settings['profiles'])}):")
+    if settings['profiles']:
+        for profile in settings['profiles']:
+            expiration = get_credential_expiration(profile)
+            if expiration:
+                from datetime import datetime, timezone
+                now = datetime.now(timezone.utc)
+                time_left = expiration - now
+                hours = time_left.total_seconds() / 3600
+                print(f"  - {profile}: expires in {hours:.1f} hours ({expiration})")
+            else:
+                print(f"  - {profile}: no valid credentials")
+    else:
+        print("  (none)")
+
+    print()

--- a/tokendito/renewal.py
+++ b/tokendito/renewal.py
@@ -1,0 +1,453 @@
+# vim: set filetype=python ts=4 sw=4
+# -*- coding: utf-8 -*-
+"""Credential auto-renewal management for tokendito."""
+
+import configparser
+import logging
+import os
+import time
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
+
+
+def parse_expiration_time(expiration_str):
+    """Parse AWS credential expiration timestamp.
+
+    AWS stores expiration in ISO 8601 format with timezone.
+
+    :param expiration_str: ISO 8601 timestamp string
+    :return: datetime object or None
+    """
+    try:
+        # Parse ISO 8601 format: 2026-03-20T08:00:46+00:00
+        if expiration_str:
+            # Handle both +00:00 and Z timezone formats
+            expiration_str = expiration_str.replace('Z', '+00:00')
+            dt = datetime.fromisoformat(expiration_str)
+            return dt
+    except (ValueError, AttributeError) as err:
+        logger.debug(f"Could not parse expiration time '{expiration_str}': {err}")
+    return None
+
+
+def get_credential_expiration(profile_name, credentials_file=None):
+    """Get expiration time for a specific AWS profile.
+
+    :param profile_name: AWS profile name
+    :param credentials_file: Path to AWS credentials file (default: ~/.aws/credentials)
+    :return: datetime object or None
+    """
+    if not credentials_file:
+        credentials_file = os.path.join(os.path.expanduser("~"), ".aws", "credentials")
+
+    if not os.path.exists(credentials_file):
+        logger.debug(f"Credentials file not found: {credentials_file}")
+        return None
+
+    try:
+        config = configparser.RawConfigParser()
+        config.read(credentials_file)
+
+        if not config.has_section(profile_name):
+            logger.debug(f"Profile '{profile_name}' not found in credentials file")
+            return None
+
+        # AWS CLI stores expiration as x_security_token_expires
+        expiration_key = "x_security_token_expires"
+        if config.has_option(profile_name, expiration_key):
+            expiration_str = config.get(profile_name, expiration_key)
+            return parse_expiration_time(expiration_str)
+
+        logger.debug(f"No expiration time found for profile '{profile_name}'")
+        return None
+
+    except (configparser.Error, OSError) as err:
+        logger.error(f"Error reading credentials file: {err}")
+        return None
+
+
+def check_profile_needs_renewal(profile_name, renewal_threshold_minutes=30, credentials_file=None):
+    """Check if a profile needs renewal.
+
+    :param profile_name: AWS profile name
+    :param renewal_threshold_minutes: Minutes before expiration to trigger renewal
+    :param credentials_file: Path to AWS credentials file
+    :return: tuple (needs_renewal: bool, time_until_expiration: timedelta or None)
+    """
+    expiration = get_credential_expiration(profile_name, credentials_file)
+
+    if not expiration:
+        logger.debug(f"Profile '{profile_name}' has no expiration time, needs renewal")
+        return (True, None)
+
+    now = datetime.now(timezone.utc)
+    time_until_expiration = expiration - now
+
+    # Check if expired or within threshold
+    threshold = timedelta(minutes=renewal_threshold_minutes)
+    needs_renewal = time_until_expiration <= threshold
+
+    logger.debug(
+        f"Profile '{profile_name}': expires in {time_until_expiration}, "
+        f"threshold {threshold}, needs_renewal={needs_renewal}"
+    )
+
+    return (needs_renewal, time_until_expiration)
+
+
+def renew_profiles(profile_names, config_file=None):
+    """Renew credentials for multiple profiles at once.
+
+    This executes tokendito with --multi-profiles to renew all profiles
+    with a single Okta authentication.
+
+    :param profile_names: List of profile names from tokendito config
+    :param config_file: Path to tokendito config file
+    :return: True if successful, False otherwise
+    """
+    import subprocess
+
+    if not profile_names:
+        logger.warning("No profiles provided for renewal")
+        return True
+
+    # Build command with --multi-profiles for each profile
+    cmd = ["tokendito"]
+    for profile_name in profile_names:
+        cmd.extend(["--multi-profiles", profile_name])
+
+    if config_file:
+        cmd.extend(["--config-file", config_file])
+
+    profile_list = ", ".join(profile_names)
+    logger.info(f"Renewing credentials for {len(profile_names)} profiles: {profile_list}")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=600  # 10 minute timeout for multiple profiles
+        )
+
+        if result.returncode == 0:
+            logger.info(f"Successfully renewed credentials for all {len(profile_names)} profiles")
+            return True
+        else:
+            logger.error(
+                f"Failed to renew credentials: {result.stderr}"
+            )
+            return False
+
+    except subprocess.TimeoutExpired:
+        logger.error(f"Timeout renewing credentials for profiles: {profile_list}")
+        return False
+    except Exception as err:
+        logger.error(f"Error renewing credentials: {err}")
+        return False
+
+
+def get_auto_renew_config(config_file=None):
+    """Read auto-renewal configuration from tokendito config file.
+
+    :param config_file: Path to tokendito config file
+    :return: dict with auto-renewal settings
+    """
+    if not config_file:
+        from tokendito.config import config as default_config
+        config_file = default_config.user["config_file"]
+
+    config_file = os.path.expanduser(config_file)
+
+    settings = {
+        "enabled": False,
+        "profiles": [],
+        "renewal_threshold_minutes": 30,
+        "check_interval_minutes": 10,
+        "max_sleep_minutes": 60,
+    }
+
+    if not os.path.exists(config_file):
+        logger.debug(f"Config file not found: {config_file}")
+        return settings
+
+    try:
+        config = configparser.RawConfigParser()
+        config.read(config_file)
+
+        section = "auto-renewal"
+        if config.has_section(section):
+            if config.has_option(section, "enabled"):
+                settings["enabled"] = config.getboolean(section, "enabled")
+
+            if config.has_option(section, "profiles"):
+                profiles_str = config.get(section, "profiles")
+                # Support comma-separated list
+                settings["profiles"] = [p.strip() for p in profiles_str.split(",") if p.strip()]
+
+            if config.has_option(section, "renewal_threshold_minutes"):
+                settings["renewal_threshold_minutes"] = config.getint(
+                    section, "renewal_threshold_minutes"
+                )
+
+            if config.has_option(section, "check_interval_minutes"):
+                settings["check_interval_minutes"] = config.getint(
+                    section, "check_interval_minutes"
+                )
+
+            if config.has_option(section, "max_sleep_minutes"):
+                settings["max_sleep_minutes"] = config.getint(
+                    section, "max_sleep_minutes"
+                )
+
+        logger.debug(f"Auto-renewal settings: {settings}")
+        return settings
+
+    except (configparser.Error, ValueError) as err:
+        logger.error(f"Error reading auto-renewal config: {err}")
+        return settings
+
+
+def save_auto_renew_config(settings, config_file=None):
+    """Save auto-renewal configuration to tokendito config file.
+
+    :param settings: dict with auto-renewal settings
+    :param config_file: Path to tokendito config file
+    :return: True if successful, False otherwise
+    """
+    if not config_file:
+        from tokendito.config import config as default_config
+        config_file = default_config.user["config_file"]
+
+    config_file = os.path.expanduser(config_file)
+
+    # Ensure directory exists
+    config_dir = os.path.dirname(config_file)
+    os.makedirs(config_dir, exist_ok=True)
+
+    try:
+        config = configparser.RawConfigParser()
+        if os.path.exists(config_file):
+            config.read(config_file)
+
+        section = "auto-renewal"
+        if not config.has_section(section):
+            config.add_section(section)
+
+        config.set(section, "enabled", str(settings.get("enabled", False)).lower())
+
+        profiles = settings.get("profiles", [])
+        config.set(section, "profiles", ", ".join(profiles))
+
+        config.set(
+            section,
+            "renewal_threshold_minutes",
+            str(settings.get("renewal_threshold_minutes", 30))
+        )
+
+        config.set(
+            section,
+            "check_interval_minutes",
+            str(settings.get("check_interval_minutes", 10))
+        )
+
+        config.set(
+            section,
+            "max_sleep_minutes",
+            str(settings.get("max_sleep_minutes", 60))
+        )
+
+        with open(config_file, "w") as f:
+            config.write(f)
+
+        logger.info(f"Saved auto-renewal configuration to {config_file}")
+        return True
+
+    except (configparser.Error, OSError) as err:
+        logger.error(f"Error saving auto-renewal config: {err}")
+        return False
+
+
+def run_renewal_check(config_file=None):
+    """Run a single renewal check for all configured profiles.
+
+    Collects all profiles that need renewal and renews them together
+    using --multi-profiles for a single Okta authentication.
+
+    :param config_file: Path to tokendito config file
+    :return: Number of profiles renewed
+    """
+    settings = get_auto_renew_config(config_file)
+
+    if not settings["enabled"]:
+        logger.info("Auto-renewal is disabled")
+        return 0
+
+    if not settings["profiles"]:
+        logger.warning("No profiles configured for auto-renewal")
+        return 0
+
+    logger.info(f"Checking {len(settings['profiles'])} profiles for renewal")
+
+    # Collect all profiles that need renewal
+    profiles_to_renew = []
+    for profile_name in settings["profiles"]:
+        needs_renewal, time_left = check_profile_needs_renewal(
+            profile_name,
+            settings["renewal_threshold_minutes"]
+        )
+
+        if needs_renewal:
+            logger.info(f"Profile '{profile_name}' needs renewal")
+            profiles_to_renew.append(profile_name)
+        else:
+            if time_left:
+                logger.debug(
+                    f"Profile '{profile_name}' does not need renewal yet "
+                    f"(expires in {time_left})"
+                )
+
+    # Renew all profiles at once with a single Okta authentication
+    if profiles_to_renew:
+        logger.info(
+            f"Renewing {len(profiles_to_renew)} profiles with single authentication"
+        )
+        if renew_profiles(profiles_to_renew, config_file):
+            logger.info(f"Successfully renewed {len(profiles_to_renew)} profiles")
+            return len(profiles_to_renew)
+        else:
+            logger.error("Failed to renew profiles")
+            return 0
+    else:
+        logger.info("No profiles need renewal at this time")
+        return 0
+
+
+def calculate_next_check_time(profiles, renewal_threshold_minutes, check_interval_minutes, max_sleep_minutes=60):
+    """Calculate when the next credential check should occur.
+
+    Checks all profiles and returns the time to sleep until the earliest
+    credential needs renewal. Falls back to check_interval if no expirations found.
+
+    Sleep time is capped at max_sleep_minutes to ensure config changes are picked up
+    promptly (e.g., if user adds a new profile with shorter expiration).
+
+    :param profiles: List of profile names to check
+    :param renewal_threshold_minutes: Minutes before expiration to trigger renewal
+    :param check_interval_minutes: Default check interval as fallback
+    :param max_sleep_minutes: Maximum sleep time in minutes (default: 60)
+    :return: Number of seconds to sleep
+    """
+    from datetime import datetime, timedelta, timezone
+
+    earliest_renewal = None
+    now = datetime.now(timezone.utc)
+
+    for profile_name in profiles:
+        expiration = get_credential_expiration(profile_name)
+        if expiration:
+            # Calculate when renewal should happen (threshold before expiration)
+            renewal_time = expiration - timedelta(minutes=renewal_threshold_minutes)
+
+            if renewal_time > now:  # Only consider future renewals
+                if earliest_renewal is None or renewal_time < earliest_renewal:
+                    earliest_renewal = renewal_time
+
+    if earliest_renewal:
+        # Calculate sleep time with a small buffer (1 minute early)
+        sleep_seconds = max(60, (earliest_renewal - now).total_seconds() - 60)
+
+        # Cap at max_sleep_minutes to allow config changes to be picked up
+        max_sleep_seconds = max_sleep_minutes * 60
+        if sleep_seconds > max_sleep_seconds:
+            logger.debug(
+                f"Next renewal needed at {earliest_renewal}, "
+                f"but capping sleep at {max_sleep_minutes} minutes to check for config changes"
+            )
+            return max_sleep_seconds
+
+        logger.debug(
+            f"Next renewal needed at {earliest_renewal}, "
+            f"sleeping for {sleep_seconds / 60:.1f} minutes"
+        )
+        return sleep_seconds
+    else:
+        # No valid expirations found, use default interval
+        logger.debug(
+            f"No valid expiration times found, using default interval of "
+            f"{check_interval_minutes} minutes"
+        )
+        return check_interval_minutes * 60
+
+
+def run_renewal_daemon(config_file=None):
+    """Run the renewal daemon - continuously check and renew credentials.
+
+    This function intelligently schedules checks based on credential expiration times
+    rather than polling at fixed intervals.
+
+    :param config_file: Path to tokendito config file
+    """
+    logger.info("Starting tokendito renewal daemon")
+
+    while True:
+        try:
+            settings = get_auto_renew_config(config_file)
+
+            if not settings["enabled"]:
+                logger.info("Auto-renewal disabled, exiting daemon")
+                break
+
+            # Run renewal check
+            run_renewal_check(config_file)
+
+            # Calculate optimal sleep time based on credential expirations
+            sleep_seconds = calculate_next_check_time(
+                settings["profiles"],
+                settings["renewal_threshold_minutes"],
+                settings["check_interval_minutes"],
+                settings["max_sleep_minutes"],
+            )
+
+            logger.debug(f"Sleeping for {sleep_seconds / 60:.1f} minutes")
+            time.sleep(sleep_seconds)
+
+        except KeyboardInterrupt:
+            logger.info("Renewal daemon interrupted by user")
+            break
+        except Exception as err:
+            logger.error(f"Error in renewal daemon: {err}", exc_info=True)
+            # Sleep a bit before retrying
+            time.sleep(60)
+
+
+def main():
+    """Entry point for renewal daemon."""
+    import argparse
+    parser = argparse.ArgumentParser(description="Tokendito credential auto-renewal daemon")
+    parser.add_argument(
+        "--config-file",
+        help="Path to tokendito configuration file"
+    )
+    parser.add_argument(
+        "--check-once",
+        action="store_true",
+        help="Run a single renewal check and exit"
+    )
+    args = parser.parse_args()
+
+    # Set up logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s |%(name)s %(funcName)s():%(lineno)i| %(message)s"
+    )
+
+    if args.check_once:
+        run_renewal_check(args.config_file)
+    else:
+        run_renewal_daemon(args.config_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tokendito/renewal.py
+++ b/tokendito/renewal.py
@@ -106,14 +106,21 @@ def renew_profiles(profile_names, config_file=None):
     :param config_file: Path to tokendito config file
     :return: True if successful, False otherwise
     """
+    import shutil
     import subprocess
 
     if not profile_names:
         logger.warning("No profiles provided for renewal")
         return True
 
+    # Find the tokendito command (important for launchd which doesn't have user's PATH)
+    tokendito_cmd = shutil.which("tokendito")
+    if not tokendito_cmd:
+        logger.error("tokendito command not found in PATH")
+        return False
+
     # Build command with --multi-profiles for each profile
-    cmd = ["tokendito"]
+    cmd = [tokendito_cmd]
     for profile_name in profile_names:
         cmd.extend(["--multi-profiles", profile_name])
 

--- a/tokendito/user.py
+++ b/tokendito/user.py
@@ -300,6 +300,26 @@ def parse_cli_args(args):
         help="Login timeout in seconds (default: 0, which is disabled). "
         "You can also use the TOKENDITO_USER_LOGIN_TIMEOUT environment variable.",
     )
+    parser.add_argument(
+        "--auto-renew-enable",
+        action="store_true",
+        help="Enable automatic credential renewal for specified profiles.",
+    )
+    parser.add_argument(
+        "--auto-renew-disable",
+        action="store_true",
+        help="Disable automatic credential renewal.",
+    )
+    parser.add_argument(
+        "--auto-renew-status",
+        action="store_true",
+        help="Display auto-renewal status and monitored profiles.",
+    )
+    parser.add_argument(
+        "--auto-renew-profiles",
+        action="append",
+        help="Profile names to monitor for auto-renewal (can be specified multiple times).",
+    )
 
     parsed_args = parser.parse_args(args)
 
@@ -1166,9 +1186,13 @@ def set_local_credentials(response={}, role="default", region="us-east-1", outpu
         aws_access_key_id = response["Credentials"]["AccessKeyId"]
         aws_secret_access_key = response["Credentials"]["SecretAccessKey"]
         aws_session_token = response["Credentials"]["SessionToken"]
+        expiration = response["Credentials"]["Expiration"]
     except KeyError as err:
         logger.error(f"Could not retrieve crendentials: {err}")
         sys.exit(1)
+
+    # Store expiration time in ISO 8601 format for auto-renewal
+    expiration_str = expiration.isoformat() if hasattr(expiration, 'isoformat') else str(expiration)
 
     update_ini(
         profile=role,
@@ -1176,6 +1200,7 @@ def set_local_credentials(response={}, role="default", region="us-east-1", outpu
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         aws_session_token=aws_session_token,
+        x_security_token_expires=expiration_str,
     )
 
     update_ini(
@@ -1488,6 +1513,33 @@ def process_options(args):
 
     if args.configure and args.configure is not True:
         _handle_configure_subcommand(args)
+
+    # Handle auto-renewal commands
+    if args.auto_renew_status:
+        from tokendito import daemon
+        daemon.display_status(args.user_config_file)
+        sys.exit(0)
+
+    if args.auto_renew_enable:
+        from tokendito import daemon
+        if not args.auto_renew_profiles:
+            logger.error("--auto-renew-profiles must be specified when enabling auto-renewal")
+            sys.exit(1)
+        if daemon.enable_auto_renewal(args.auto_renew_profiles, args.user_config_file):
+            print(f"Auto-renewal enabled for profiles: {', '.join(args.auto_renew_profiles)}")
+        else:
+            logger.error("Failed to enable auto-renewal")
+            sys.exit(1)
+        sys.exit(0)
+
+    if args.auto_renew_disable:
+        from tokendito import daemon
+        if daemon.disable_auto_renewal(args.user_config_file):
+            print("Auto-renewal disabled")
+        else:
+            logger.error("Failed to disable auto-renewal")
+            sys.exit(1)
+        sys.exit(0)
 
     _load_config_sources(args)
 


### PR DESCRIPTION
## Summary

Implements automatic renewal of AWS credentials before expiration, eliminating manual re-authentication throughout the workday.

## Key Features

- **Background daemon** monitors specified profiles and auto-renews before expiration
- **Intelligent scheduling**: sleeps until renewal needed (no constant polling)
- **Batch renewal**: multiple profiles renewed with single Okta authentication using `--multi-profiles`
- **Config responsiveness**: max_sleep_minutes ensures config changes picked up promptly
- **macOS launchd integration**: service survives system sleep/wake
- **Device token support**: passwordless renewal after initial authentication
- **Expiration tracking**: stores credential expiration in ~/.aws/credentials

## New CLI Commands

```bash
# Enable auto-renewal
tokendito --auto-renew-enable \
    --auto-renew-profiles default \
    --auto-renew-profiles cicd_prod

# Check status
tokendito --auto-renew-status

# Disable
tokendito --auto-renew-disable

# Manual daemon
tokendito-renew-daemon [--check-once]
```

## Configuration

Settings stored in `tokendito.ini`:
```ini
[auto-renewal]
enabled = true
profiles = profile1, profile2
renewal_threshold_minutes = 30
check_interval_minutes = 10
max_sleep_minutes = 60
```

## Technical Details

### Intelligent Scheduling
- Daemon calculates when credentials expire
- Sleeps until renewal time (not polling at intervals)
- Example: 12-hour credentials → wakes up every 60 min to check config, renews at 11.5 hour mark
- Max sleep cap ensures config changes picked up within 60 minutes

### Batch Renewal Efficiency
- Uses `tokendito --multi-profiles profile1 --multi-profiles profile2 ...`
- **Single Okta authentication** for all profiles needing renewal
- Much more efficient than individual renewals

### Platform Support
- **macOS**: Full support with automatic launchd service
- **Linux/Windows**: Manual daemon execution (systemd/Task Scheduler recommended)

## Test Coverage

- 29 unit tests (100% passing)
- Comprehensive coverage of renewal logic, scheduling, and daemon operations
- Mock-based tests (no external dependencies)

## Documentation

- `docs/AUTO_RENEWAL.md`: Complete user guide
- Multiple technical guides and quick start documentation
- Updated main README with auto-renewal section

## Test Plan

- [x] Unit tests pass
- [x] Manual testing on macOS with 6 profiles
- [x] Verified launchd service starts and runs
- [x] Confirmed batch renewal with --multi-profiles
- [x] Validated intelligent scheduling calculations
- [x] Tested config change detection (max_sleep_minutes)
- [x] Verified expiration tracking in credentials file
- [ ] Integration testing with real credentials
- [ ] Long-term stability testing (24+ hours)

## Breaking Changes

None. This is a new feature with no impact on existing functionality.

## Related Issues

Implements credential auto-renewal functionality requested for continuous development workflows.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)